### PR TITLE
  Use image hook to generate image if image is not provided to Notion

### DIFF
--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -19,7 +19,10 @@ const PostItem: React.FC<Props> = ({ post }) => {
     [post.properties.Date.date.start]
   )
 
-  const image = useOgImage({
+  // use image hook to generate image if image is not provided to Image Column
+  let image
+
+  post.properties.Image.url ? image = post.properties.Image.url : image = useOgImage({
     title: post.properties.Page.title[0].plain_text ?? "",
     authorName: post.properties.Authors.people[0].name ?? "",
   })


### PR DESCRIPTION
  Use image hook to generate image only if image is not provided to Notion's image column. Prior to this PR, the image column was not being read at all.