### PR TITLE
Rendering improvements

### DIFF
--- a/components/NotionText.tsx
+++ b/components/NotionText.tsx
@@ -1,7 +1,8 @@
 import Link from "@components/Link"
 import React, { Fragment } from "react"
+import Image from "next/image"
 
-// const TEMPLATE_PATH = "https://railway.app/new/template"
+const TEMPLATE_PATH = "https://railway.app/new/template"
 
 /**
  * This type is harcoded here as I couldn't really find anything
@@ -71,16 +72,25 @@ export const NotionText: React.FC<{
         return (
           <Fragment key={idx}>
             {text.link != null && !noLinks ? (
-              <Link
-                href={text.link.url}
-                className="underline hover:text-pink-600"
-              >
-                <RenderTextContent
-                  isCode={code}
-                  content={text.content}
-                  className={classes}
-                />
-              </Link>
+              <>
+                {text.link.url.includes(TEMPLATE_PATH) &&
+                text.content === text.link.url ? (
+                  <Link href={text.link.url} className="flex justify-center">
+                    <Image src="/button.svg" height={48} width={240} alt="" />
+                  </Link>
+                ) : (
+                  <Link
+                    href={text.link.url}
+                    className="underline hover:text-pink-600"
+                  >
+                    <RenderTextContent
+                      isCode={code}
+                      content={text.content}
+                      className={classes}
+                    />
+                  </Link>
+                )}
+              </>
             ) : (
               <RenderTextContent
                 isCode={code}

--- a/lib/notion/index.ts
+++ b/lib/notion/index.ts
@@ -26,7 +26,8 @@ export const getDatabase = async (databaseId: string) => {
         r.properties.Date.date != null &&
         r.properties.Description.rich_text.length > 0 &&
         r.properties.Slug.rich_text.length > 0 &&
-        r.properties.Page.title.length > 0
+        r.properties.Page.title.length > 0 &&
+        r.properties.Authors.people.length > 0
     )
     .sort((a, b) => {
       const dateA = new Date(a.properties.Date.date.start)


### PR DESCRIPTION
This PR:
- Ensures the `author` field is populated on posts in Notion.
- Closes PRO-99 by fixing the rendering of template URLs