### PR TITLE
add rust and go syntax highlighting

### DIFF
--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -20,7 +20,7 @@ export const Code: React.FC<{ children: string; language?: string }> = ({
   useAsyncEffect(async () => {
     setMarkupToHighlight(
       await getHighlighter({
-        langs: ["html", "javascript", "typescript", "shell"],
+        langs: ["html", "javascript", "typescript", "shell", "rust", "go"],
         theme: theme === "light" ? LIGHT_THEME : DARK_THEME,
       }).then((highlighter) =>
         highlighter.codeToHtml(children, { lang: language })


### PR DESCRIPTION
Adds `Rust` and `Go` syntax highlighting to code blocks

Before
<img width="1392" alt="Screenshot 2023-03-10 at 12 52 30 PM" src="https://user-images.githubusercontent.com/18741261/224426035-824314ee-6bd9-4737-9514-29248ab54dab.png">


After
<img width="1392" alt="Screenshot 2023-03-10 at 12 52 00 PM" src="https://user-images.githubusercontent.com/18741261/224426050-d8bded05-09a7-407c-a9dd-1d3b56ff2828.png">
