### PR TITLE
Add rss button to header nav

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Link from "@components/Link"
 import Logo from "@components/Logo"
-import { Moon, Sun } from "react-feather"
+import { Moon, Sun, Rss } from "react-feather"
 import { useTheme } from "next-themes"
 import { useIsMounted } from "../hooks/useIsMounted"
 import { useRouter } from "next/router"
@@ -34,6 +34,13 @@ const Nav: React.FC = () => {
           >
             Go to Homepage
           </Link>
+
+          <button
+            className="hover:text-pink-600"
+            onClick={() => window.open("https://blog.railway.app/rss.xml")}
+          >
+            <Rss size={16} />
+          </button>
 
           {isMounted && (
             <button


### PR DESCRIPTION
This adds an RSS icon/link to the blog header nav per [PRO-1509](https://linear.app/railway/issue/PRO-1509/add-rss-link-somewhere-on-the-blog)

<img width="1392" alt="Screenshot 2023-11-27 at 12 32 40 PM" src="https://github.com/railwayapp/blog/assets/18741261/d8434c5a-d227-4a99-88e7-d146f9dc3aad">
