### PR TITLE
Support nested callouts

### DIFF
--- a/components/RenderBlock.tsx
+++ b/components/RenderBlock.tsx
@@ -14,6 +14,11 @@ interface Props {
   block: Block
 }
 
+// TODO: IDK where notion types are when you upgrade the API
+type NotionBlock = Block & {
+  children: Block[]
+}
+
 export const RenderBlock: React.FC<Props> = ({ block }) => {
   const { type } = block
   const value = block[type]
@@ -53,13 +58,24 @@ export const RenderBlock: React.FC<Props> = ({ block }) => {
     }
     // @ts-ignore: Current client version does not support `callout` but API does
     case "callout": {
+      console.log("callout", block)
+      const callout = (block as any).callout
       return (
         <div className="flex w-full p-4 my-8 rounded border border-transparent bg-blue-100">
           {value.icon.emoji && (
             <div className="text-yellow-500">{value.icon.emoji}</div>
           )}
-          <div className="ml-4 text-foreground">
-            <NotionText text={value.text} />
+          <div className="flex flex-col w-full">
+            <div className="ml-4 text-foreground">
+              <NotionText text={value.text} />
+            </div>
+            {callout.children ? (
+              <div className="flex flex-col p-4">
+                {callout.children.map((child) => (
+                  <RenderBlock block={child} />
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       )


### PR DESCRIPTION
This PR (jankily) supports nested callouts

I tried to upgrade the API but found out they pulled the types from the original package. Spent 20 minutes trying to get types on the new version of the client to work and then just used an "any" instead
