### PR TITLE
Fix rendering for ordered list items

### DIFF
--- a/components/ListBlock.tsx
+++ b/components/ListBlock.tsx
@@ -19,7 +19,9 @@ export const NotionListBlock: React.FC<{
 
 const RenderListItem: React.FC<{ item: Block }> = ({ item }) => {
   const children = useMemo(() => {
-    return ((item as any).bulleted_list_item?.children ?? []) as Block[]
+    return ((item as any).bulleted_list_item?.children ??
+      (item as any).numbered_list_item?.children ??
+      []) as Block[]
   }, [item])
 
   const subListBlock: ListBlock | null = useMemo(() => {

--- a/components/NotionText.tsx
+++ b/components/NotionText.tsx
@@ -117,5 +117,5 @@ export const NotionList: React.FC<{
   type === "ul" ? (
     <ul className={twMerge("list-disc pl-6 mb-6", className)}>{children}</ul>
   ) : (
-    <ol className={twMerge("list-disc pl-6 mb-6", className)}>{children}</ol>
+    <ol className={twMerge("list-decimal pl-6 mb-6", className)}>{children}</ol>
   )


### PR DESCRIPTION
## What's the issue?

This PR fixes the rendering to `ol` list items, including the nested rendering. 

## Explanation
Upon inspecting I figured that the `ol` list items were not rendering properly because
- The list rendering element was using `list-disc` tailwind classname for both `ol` and `ul`.
- The nested rendering logic didn't include the `numbered_list_item` property.

## Preview

The page content in Notion:
![Notion content](https://github.com/user-attachments/assets/d92a527b-d4c8-4846-9bb6-d4c1900e05ab)

Rendered output before the fix:
![Before changes](https://github.com/user-attachments/assets/98ea14ed-7b5b-452d-86d9-748f50f29186)

Rendered output after the fix:
![After changes](https://github.com/user-attachments/assets/b31d9671-ad64-404d-8bb1-9bf7626991e5)
