### PR TITLE
Update fathom to receive events from blog.railway.com

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import { Inter } from "@next/font/google"
 const inter = Inter({ subsets: ["latin"] })
 
 const RailwayBlog = ({ Component, pageProps }: AppProps) => {
-  useFathom(process.env.NEXT_PUBLIC_FATHOM_CODE ?? "", "blog.railway.app")
+  useFathom(process.env.NEXT_PUBLIC_FATHOM_CODE ?? "", "blog.railway.com")
 
   const { bodyCSS } = useMemo(
     () =>


### PR DESCRIPTION
Fathom has not received blog events since 11/15. I believe this is the fix.

<img width="1028" alt="Screenshot 2024-11-19 at 8 35 44 AM" src="https://github.com/user-attachments/assets/98620499-0550-427f-b62d-a03c97ec5101">
