### PR TITLE
fix: make YouTube ID extraction robust and add tests

### DIFF
--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,19 @@
+import { extractYoutubeId } from "../utils"
+
+describe("extractYoutubeId", () => {
+  it("handles watch URLs with extra parameters", () => {
+    const url =
+      "https://www.youtube.com/watch?feature=share&v=dQw4w9WgXcQ&t=30s"
+    expect(extractYoutubeId(url)).toBe("dQw4w9WgXcQ")
+  })
+
+  it("returns null when id is missing", () => {
+    const url = "https://www.youtube.com/watch?feature=share"
+    expect(extractYoutubeId(url)).toBeNull()
+  })
+
+  it("extracts id from short URLs with params", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ?si=abc"
+    expect(extractYoutubeId(url)).toBe("dQw4w9WgXcQ")
+  })
+})

--- a/utils.ts
+++ b/utils.ts
@@ -5,7 +5,7 @@ export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs))
 
 export const extractYoutubeId = (url: string): string | null => {
   const matched = url.match(
-    /.*(?:youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=)([^#\\&\\?]*).*/
+    /(?:youtu\.be\/|v\/|u\/\w\/|embed\/|watch.*[?&]v=)([^#&?]+)/
   )
-  return matched && matched.length >= 1 ? matched[1] : null
+  return matched && matched[1] ? matched[1] : null
 }


### PR DESCRIPTION
Updates extractYoutubeId with a tighter regex to handle watch URLs with extra params and youtu.be short links, returning null when missing. Adds unit tests covering watch with params, missing id, and short URL with params. Improves reliability without changing the public API.