### PR TITLE
refactor: avoid mutating prop and use displayCategory

### DIFF
--- a/components/ContinueReading.tsx
+++ b/components/ContinueReading.tsx
@@ -11,7 +11,7 @@ export const ContinueReading: React.FC<{
   posts: PostProps[]
   category: string
 }> = ({ posts, category }) => {
-  category = category === "Guide" ? "Guides" : category
+  const displayCategory = category === "Guide" ? "Guides" : category
 
   return (
     <div>
@@ -21,9 +21,9 @@ export const ContinueReading: React.FC<{
         </h3>
         <Link
           className={cn("text-pink-500", "hover:underline")}
-          href={`/${category.toLowerCase()}`}
+          href={`/${displayCategory.toLowerCase()}`}
         >
-          View All {category} →
+          View All {displayCategory} →
         </Link>
       </header>
 


### PR DESCRIPTION
Mutating props is avoided because props are designed to be immutable inputs from the parent. Changing them inside a component can break React’s one-way data flow, cause render mismatches, and make debugging harder. Using a derived variable (displayCategory) keeps behavior predictable and maintainable.