### PR TITLE
fix: add try/catch and 500 response to image endpoint

### DIFF
--- a/pages/api/image.ts
+++ b/pages/api/image.ts
@@ -9,8 +9,12 @@ const handler: NextApiHandler = async (req, res) => {
     return
   }
 
-  const imageSrc = await getChangelogImageSrc(blockId)
-  res.json({ imageSrc })
+  try {
+    const imageSrc = await getChangelogImageSrc(blockId)
+    return res.json({ imageSrc })
+  } catch {
+    return res.status(500).json({ message: "Failed to fetch image" })
+  }
 }
 
 export default handler


### PR DESCRIPTION
Adds error handling to the image API by wrapping getChangelogImageSrc in a try/catch and returning a 500 on failure.