### PR TITLE
Improve RSS feed accessibility

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -35,12 +35,13 @@ const Nav: React.FC = () => {
             Go to Homepage
           </Link>
 
-          <button
-            className="hover:text-pink-600"
-            onClick={() => window.open("https://blog.railway.com/rss.xml")}
+          <a
+            href="https://blog.railway.com/rss.xml" 
+            className="outline-offset-4"
           >
             <Rss size={16} />
-          </button>
+            <span className="sr-only">RSS feed</span>
+          </a>
 
           {isMounted && (
             <button


### PR DESCRIPTION
This PR changes the RSS feed from an button to a link for better semantic, increases the outline offset, and adds screen reader-only text to comply with [Success Criterion 1.1.1 (Non-text content)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html).

| Before (focused) | After (focused) |
| -------- | ----- |
| <img width="225" height="60" alt="image" src="https://github.com/user-attachments/assets/f655749f-09c3-446e-8eed-2e2c04f64d37" /> | <img width="197" height="56" alt="image" src="https://github.com/user-attachments/assets/ab5fea35-1b83-43e3-94a0-2cc9f6c9ba2a" />  |

I assume it was a button with `window.open()` before to open it in a new tab. This can be replicated with `target="_blank" rel="noopener noreferrer"` instead. I haven't done so since it's generally a bad practice to take control over this from the user, but we can change if there's a reason to.

These changes were tested manually with NVDA on Windows. For reference, before the element was announced as "button", and with the changes, "rss feed, link".