### PR TITLE
Improve theme switch accessibility

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -44,10 +44,11 @@ const Nav: React.FC = () => {
 
           {isMounted && (
             <button
-              className="hover:text-pink-600"
+              className="hover:text-pink-600 outline-offset-4"
               onClick={() => setTheme(theme === "light" ? "dark" : "light")}
             >
               {theme === "light" ? <Moon size={16} /> : <Sun size={16} />}
+              <span className="sr-only" aria-live="polite">Toggle {theme === "dark" ? "light" : "dark"} mode</span>
             </button>
           )}
         </div>


### PR DESCRIPTION
This PR brings the same changes I did in https://github.com/railwayapp/docs/pull/977 to make the theme switch more accessible:

- Added `outline-offset-4` to add some breathing space for the theme switch icons.
	
	| Before (focused) | After (focused) |
	| -------- | ----- |
	| <img width="215" height="56" alt="image" src="https://github.com/user-attachments/assets/bd737e72-17ff-4bc8-85f0-ba8e3b036941" /> | <img width="201" height="53" alt="image" src="https://github.com/user-attachments/assets/c914f51d-a3c1-43f0-ae86-8e3f22eba598" /> |

- The theme switch didn't have any text indication of what it does, so for example, users with impaired vision that depend screen readers couldn't know what the button does. Additionally, there's no indication of its state. [Success Criterion 1.1.1 (Non-text Content)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html) and [Success Criterion 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).

	Solution: added a screen reader-only "Toggle [mode] mode" span, that both indicates the theme switcher is a theme toggler and its state whenever clicked thanks to the added `aria-live="polite"` attribute.
	
	The changes were manually tested using NVDA on Windows. For reference, before the announcement would be "button" and now (assuming you're currently in the dark mode), "button, toggle light mode".