### PR TITLE
fix: align post header and author meta with article body

### DIFF
--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -66,7 +66,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts, blocks, children
               : "pb-12"
           )}
         >
-          <div className="flex items-center text-gray-500 space-x-3">
+          <div className="flex items-center text-gray-500 space-x-3 max-w-[736px] mx-auto">
             {authors.length > 0 && (
               <>
                 <div className="flex items-center space-x-3">
@@ -91,7 +91,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts, blocks, children
             </time>
           </div>
 
-          <header className="mt-5 mb-16 max-w-[800px]">
+          <header className="mt-5 mb-16 max-w-[736px] mx-auto">
             <h1 className="text-huge font-bold">
               <NotionText text={post.properties.Page.title} />
             </h1>


### PR DESCRIPTION
## What

Author metadata (avatar, name, date) and post title were not aligned 
with the article body on wider viewports.

## Why

The body content is constrained to `max-w-[736px]` but the author row 
and header were missing `mx-auto`, causing them to render wider than 
the article body.

## Changes

In `layouts/PostPage.tsx`:
- Added `max-w-[736px] mx-auto` to the author metadata `div`
- Added `mx-auto` to the existing `max-w-[736px]` on the `<header>`

## Screenshots

**Before:**
<img width="1881" height="948" alt="before" src="https://github.com/user-attachments/assets/08deabed-2585-4304-954b-e72d1320ec8c" />

**After:**
<img width="1881" height="948" alt="after" src="https://github.com/user-attachments/assets/8507b6db-6859-405b-87dd-92d6a7fa4d65" />

Closes #87 