### PR TITLE
perf(cache): lower ISR revalidate to 5s on HTML pages

### DIFF
--- a/pages/[category].tsx
+++ b/pages/[category].tsx
@@ -51,7 +51,7 @@ export const getStaticProps: GetStaticProps = async (props) => {
   if (typeof categorySlug !== "string") {
     return {
       notFound: true,
-      revalidate: 900,
+      revalidate: 5,
     }
   }
 
@@ -64,7 +64,7 @@ export const getStaticProps: GetStaticProps = async (props) => {
     // otherwise stay a cached 404 until the next deploy.
     return {
       notFound: true,
-      revalidate: 900,
+      revalidate: 5,
     }
   }
 
@@ -72,7 +72,7 @@ export const getStaticProps: GetStaticProps = async (props) => {
 
   return {
     props: { posts, categories, category },
-    revalidate: 900,
+    revalidate: 5,
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,7 +34,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: { posts, categories },
-    revalidate: 900,
+    revalidate: 5,
   }
 }
 

--- a/pages/p/[slug].tsx
+++ b/pages/p/[slug].tsx
@@ -38,7 +38,7 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
   if (typeof slug !== "string") {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: 5,
     }
   }
 
@@ -50,7 +50,7 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
     // otherwise pin the URL at 404 after the post goes live.
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: 5,
     }
   }
 
@@ -66,7 +66,7 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
       page: post,
       relatedPosts,
     },
-    revalidate: 60,
+    revalidate: 5,
   }
 }
 


### PR DESCRIPTION
## What

Lowers ISR `revalidate` to **5s** on all HTML pages now that the Railway CDN is enabled.

| File | Before | After |
|---|---|---|
| `pages/index.tsx` (homepage) | 900s | **5s** |
| `pages/[category].tsx` (listing + `notFound`) | 900s | **5s** |
| `pages/p/[slug].tsx` (post + `notFound`) | 60s | **5s** |

Left untouched: `sitemap.xml` (`s-maxage=900`) and `llms-blog.md` (`s-maxage=3600`) — heavy to generate and rarely change.

## Why

[Railway CDN](https://docs.railway.com/networking/cdn) is now enabled. Pages Router ISR automatically emits `Cache-Control: s-maxage=<revalidate>, stale-while-revalidate`, which the CDN honors (`s-maxage` is its highest-priority directive). The edge serves stale content instantly and refreshes from origin in the background, and cache hits never reach our service — so a short TTL doesn't hammer the origin.

Net effect: CMS edits surface within ~5s of the next request instead of 1–15 min, with the CDN absorbing the load.

## Notes

- Takes effect on next deploy.
- No build run locally; only constant values changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)