### PR TITLE
Serve CMS images via imgproxy gateway transforms

### DIFF
--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -1,6 +1,6 @@
 import Link from "@components/Link"
+import { buildCMSImageSrcSet, buildCMSImageURL } from "@lib/cms/image"
 import { BlogPost } from "@lib/types"
-import Image from "next/image"
 import React, { useMemo } from "react"
 import { formatPostDate } from "../utils"
 import { Divider } from "./Divider"
@@ -18,12 +18,20 @@ export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
     <Link href={`/p/${post.slug}`} className="group">
       {featuredImage != null ? (
         <div className="w-full aspect-[2.25/1] relative border border-black border-opacity-10 rounded-xl overflow-hidden">
-          <Image
-            src={featuredImage.url}
-            fill
-            priority
+          <img
+            src={buildCMSImageURL(featuredImage.url, {
+              format: "webp",
+              width: 1200,
+            })}
+            srcSet={buildCMSImageSrcSet(featuredImage.url, {
+              format: "webp",
+              maxWidth: 1200,
+            })}
+            sizes="(max-width: 768px) 100vw, 560px"
             alt={featuredImage.alt || post.title}
-            className="object-cover transition-transform group-hover:scale-[1.05]"
+            className="absolute inset-0 w-full h-full object-cover transition-transform group-hover:scale-[1.05]"
+            decoding="async"
+            fetchPriority="high"
           />
         </div>
       ) : (

--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -25,7 +25,7 @@ export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
             })}
             srcSet={buildCMSImageSrcSet(featuredImage.url, {
               format: "webp",
-              maxWidth: 1200,
+              maxWidth: 1440,
             })}
             sizes="(max-width: 768px) 100vw, 560px"
             alt={featuredImage.alt || post.title}

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -1,5 +1,6 @@
 import Link from "@components/Link"
 import { Code } from "@components/Code"
+import { buildCMSImageSrcSet, buildCMSImageURL } from "@lib/cms/image"
 import {
   createMarkdownSlugger,
   getHeadingId,
@@ -252,7 +253,12 @@ const MarkdownSegmentRenderer: React.FC<{
       return (
         <figure className="flex flex-col my-8 space-y-2">
           <img
-            src={src}
+            src={buildCMSImageURL(src, { format: "webp", width: 768 })}
+            srcSet={buildCMSImageSrcSet(src, {
+              format: "webp",
+              maxWidth: 1600,
+            })}
+            sizes="(max-width: 768px) 100vw, 736px"
             alt={alt ?? ""}
             className="w-full rounded-lg"
             loading="lazy"

--- a/lib/cms/image.ts
+++ b/lib/cms/image.ts
@@ -12,6 +12,11 @@ export const CMS_IMAGE_WIDTHS = [
   320, 480, 640, 768, 960, 1200, 1440, 1600, 1920, 2400, 3200,
 ] as const
 
+// High quality — the resize + WebP conversion already yields ~90–98% byte
+// reduction vs the original, so we keep quality high to preserve text/UI
+// clarity. Must be one of the gateway's allowed values {60,70,75,80,85,90,95}.
+export const CMS_IMAGE_QUALITY = 90
+
 type ImageFormat = "webp" | "avif" | "jpg" | "png"
 
 interface CMSImageOptions {
@@ -63,7 +68,7 @@ export const buildCMSImageURL = (
   if (opts.height !== undefined) params.set("h", String(opts.height))
   if (opts.fit === "cover") params.set("fit", opts.fit)
   if (opts.format !== undefined) params.set("format", opts.format)
-  if (opts.quality !== undefined) params.set("q", String(opts.quality))
+  params.set("q", String(opts.quality ?? CMS_IMAGE_QUALITY))
 
   parsed.search = params.toString()
   return parsed.toString()

--- a/lib/cms/image.ts
+++ b/lib/cms/image.ts
@@ -1,0 +1,90 @@
+// Helpers for the Railway CMS imgproxy media gateway. Every CMS media URL
+// (https://cms.railway.com/media/<filename>) accepts transform query params and
+// serves resized, reformatted, CDN-cached images. We build already-canonical
+// URLs (snapped widths, canonical param order) so requests hit the CDN cache
+// directly (200) instead of triggering a 308 redirect to the canonical form.
+
+const DEFAULT_CMS_API_URL = "https://cms.railway.com"
+
+// Width ladder the gateway snaps to (rounding up). Mirrored here so the srcset
+// widths we emit are already canonical. Keep in sync with the CMS.
+export const CMS_IMAGE_WIDTHS = [
+  320, 480, 640, 768, 960, 1200, 1440, 1600, 1920, 2400, 3200,
+] as const
+
+type ImageFormat = "webp" | "avif" | "jpg" | "png"
+
+interface CMSImageOptions {
+  width?: number
+  height?: number
+  fit?: "cover" | "contain"
+  format?: ImageFormat
+  quality?: number
+}
+
+const getCMSHost = (): string | null => {
+  try {
+    return new URL(process.env.CMS_API_URL || DEFAULT_CMS_API_URL).host
+  } catch {
+    return null
+  }
+}
+
+// Only transform first-party CMS media. Everything else (GitHub avatars,
+// /public assets, SVGs, og.railway) is passed through untouched.
+export const isCMSMediaURL = (url: string): boolean => {
+  const host = getCMSHost()
+  if (!host) return false
+
+  try {
+    const parsed = new URL(url)
+    return parsed.host === host && parsed.pathname.startsWith("/media/")
+  } catch {
+    return false
+  }
+}
+
+const snapWidth = (width: number): number =>
+  CMS_IMAGE_WIDTHS.find((candidate) => candidate >= width) ??
+  CMS_IMAGE_WIDTHS[CMS_IMAGE_WIDTHS.length - 1]
+
+export const buildCMSImageURL = (
+  url: string,
+  opts: CMSImageOptions = {}
+): string => {
+  if (!isCMSMediaURL(url)) return url
+
+  const parsed = new URL(url)
+  // Build params in canonical order: w, h, fit, format, q. Drop fit=contain
+  // (the default). Preserve any pre-existing query params on the base URL.
+  const params = new URLSearchParams(parsed.search)
+
+  if (opts.width !== undefined) params.set("w", String(snapWidth(opts.width)))
+  if (opts.height !== undefined) params.set("h", String(opts.height))
+  if (opts.fit === "cover") params.set("fit", opts.fit)
+  if (opts.format !== undefined) params.set("format", opts.format)
+  if (opts.quality !== undefined) params.set("q", String(opts.quality))
+
+  parsed.search = params.toString()
+  return parsed.toString()
+}
+
+export const buildCMSImageSrcSet = (
+  url: string,
+  opts: { format?: ImageFormat; quality?: number; maxWidth?: number } = {}
+): string | undefined => {
+  if (!isCMSMediaURL(url)) return undefined
+
+  const maxWidth = opts.maxWidth ?? CMS_IMAGE_WIDTHS[CMS_IMAGE_WIDTHS.length - 1]
+
+  return CMS_IMAGE_WIDTHS.filter((width) => width <= maxWidth)
+    .map(
+      (width) =>
+        `${buildCMSImageURL(url, {
+          format: opts.format,
+          quality: opts.quality,
+          width,
+        })} ${width}w`
+    )
+    .join(", ")
+}

--- a/test/pages/not-found-revalidate.test.ts
+++ b/test/pages/not-found-revalidate.test.ts
@@ -27,10 +27,10 @@ describe("post page getStaticProps", () => {
       params: { slug: "not-published-yet" },
     })
 
-    expect(result).toEqual({ notFound: true, revalidate: 60 })
+    expect(result).toEqual({ notFound: true, revalidate: 5 })
   })
 
-  it("keeps the 60s lease on rendered posts", async () => {
+  it("keeps the 5s lease on rendered posts", async () => {
     const post = { slug: "hello-world", category: null }
     ;(getPostBySlug as jest.Mock).mockResolvedValue(post)
     ;(getRelatedPosts as jest.Mock).mockResolvedValue([])
@@ -41,7 +41,7 @@ describe("post page getStaticProps", () => {
 
     expect(result).toEqual({
       props: { page: post, relatedPosts: [] },
-      revalidate: 60,
+      revalidate: 5,
     })
   })
 })
@@ -54,6 +54,6 @@ describe("category page getStaticProps", () => {
       params: { category: "not-created-yet" },
     })
 
-    expect(result).toEqual({ notFound: true, revalidate: 900 })
+    expect(result).toEqual({ notFound: true, revalidate: 5 })
   })
 })


### PR DESCRIPTION
## What

The Railway CMS media gateway ([railwayapp/cms](https://github.com/railwayapp/cms)) now accepts transform query params on `/media/<file>` URLs, serving resized, WebP, CDN-cached images. This PR leverages it for **all** CMS images on the blog.

## Changes

- **`lib/cms/image.ts`** (new) — `buildCMSImageURL` / `buildCMSImageSrcSet` emit **already-canonical** URLs (snapped widths, canonical `w,h,fit,format,q` order) so requests hit the CDN cache directly (`200`) instead of `308`-redirecting to the canonical form. `isCMSMediaURL` gates transforms to first-party `cms.railway.com/media/*`; GitHub avatars, `/public` assets, SVGs, etc. pass through untouched.
- **`components/FeaturedPostItem.tsx`** — drops `next/image` for a plain `<img>` filling its existing `aspect-[2.25/1]` container (no CLS), with gateway `srcset`/`sizes` and `fetchPriority="high"`.
- **`components/MarkdownContent.tsx`** — body images get gateway `src`/`srcset`/`sizes` (WebP, capped at `1600w` for the 736px content column at 2× DPR). Caption logic untouched.

`CustomerStories.tsx` stays on `next/image` — those are local `/public` assets with no gateway to point at.

## Why

Offloads image optimization to imgproxy + its CDN and removes Next's redundant `/_next/image` pass for CMS images, while staying framework-agnostic (plain `<img>` + hand-built `srcset`).

## Verification

Confirmed live against `cms.railway.com`:
- Featured + body images render `…/media/<hash>.png?w=…&format=webp` in `srcset`; **no** `/_next/image` CMS requests.
- Canonical transform URL → `200`, `content-type: image/webp`, `cache-control: …s-maxage=86400, stale-while-revalidate=604800`.
- Raw (no params) → `307` to signed S3 URL (expected).
- Sample body image: **1474 KB PNG → 15 KB WebP**.
- `tsc --noEmit` clean; full jest suite (91 tests) green.

A second commit fixes a pre-existing test failure unrelated to this feature: #92 lowered ISR `revalidate` from 60/900 to 5, but `not-found-revalidate.test.ts` still expected the old values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)