### PR TITLE
Fix broken OG cards: stable image URL + empty-string SEO fallbacks

### DIFF
--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -8,6 +8,7 @@ import {
   extractFAQs,
 } from "@lib/seo-components"
 import { BlogPost } from "@lib/types"
+import { buildCMSImageURL } from "@lib/cms/image"
 
 export interface Props extends NextSeoProps {
   title?: string
@@ -61,7 +62,15 @@ const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, ...pro
     ? [author]
     : post?.authors.map((a) => a.name) || []
   const section = post?.category?.title
-  const postImage = image || post?.socialImage?.url || post?.featuredImage?.url
+  // A raw CMS media URL (cms.railway.com/media/…) 307-redirects to a
+  // short-lived signed storage URL, which social scrapers (Discord, X) fail to
+  // render. Route it through the imgproxy gateway to get a stable, CDN-cached
+  // 200. Non-CMS URLs (the og.railway.com dynamic card, manual escape hatches)
+  // pass through untouched.
+  const rawImage = image || post?.socialImage?.url || post?.featuredImage?.url
+  const postImage = rawImage
+    ? buildCMSImageURL(rawImage, { width: 1200 })
+    : undefined
 
   return (
     <>

--- a/lib/cms/index.ts
+++ b/lib/cms/index.ts
@@ -256,6 +256,14 @@ const listAllCollection = async <T>(
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === "object")
 
+// The CMS returns optional SEO fields as empty strings ("") when left blank,
+// not null. An empty string is truthy enough to defeat `?? fallback` (nullish
+// coalescing only falls back on null/undefined), which let blank seoTitle /
+// seoDescription override the post title/description and surface the generic
+// site defaults on every social card. Normalize blank/whitespace to null.
+const nonEmptyString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() !== "" ? value : null
+
 export const mapCMSMedia = (media: number | PayloadMedia | null | undefined) => {
   if (!isRecord(media) || typeof media.url !== "string" || !media.url) {
     return null
@@ -316,12 +324,8 @@ export const mapCMSCategory = (
       typeof category.description === "string" ? category.description : null,
     id: String(category.id),
     order: typeof category.order === "number" ? category.order : null,
-    seoDescription:
-      typeof category.seoDescription === "string"
-        ? category.seoDescription
-        : null,
-    seoTitle:
-      typeof category.seoTitle === "string" ? category.seoTitle : null,
+    seoDescription: nonEmptyString(category.seoDescription),
+    seoTitle: nonEmptyString(category.seoTitle),
     showInNavigation:
       typeof category.showInNavigation === "boolean"
         ? category.showInNavigation
@@ -361,9 +365,8 @@ export const mapCMSPost = (post: PayloadPost): BlogPost | null => {
     featuredImage: mapCMSMedia(post.featuredImage),
     id: String(post.id),
     publishedAt: post.publishedAt,
-    seoDescription:
-      typeof post.seoDescription === "string" ? post.seoDescription : null,
-    seoTitle: typeof post.seoTitle === "string" ? post.seoTitle : null,
+    seoDescription: nonEmptyString(post.seoDescription),
+    seoTitle: nonEmptyString(post.seoTitle),
     slug: post.slug,
     socialImage: mapCMSMedia(post.socialImage),
     title: post.title,


### PR DESCRIPTION
## Problem

OG/social cards (Discord, X) render broken on blog posts. Example: https://blog.railway.com/p/skills-issue-writing-skills

Two independent root causes, both reproduced locally:

### 1. `og:image` is a redirect to an expiring signed URL
`og:image` pointed at the raw CMS media URL (`cms.railway.com/media/<file>.png`), which **307-redirects to a signed storage URL that expires in 300s**. Scrapers that don't follow the cross-host redirect — or that cache the expiring signed target — fail to load the image.

The imgproxy gateway variant of the same image serves a clean, CDN-cached `200` (`cache-control: s-maxage=86400`).

### 2. Blank SEO fields defeat `??` fallbacks → generic defaults on every post
The CMS returns blank `seoTitle`/`seoDescription` as **empty strings** (`""`), and consumers used `post.seoTitle ?? post.title`. Nullish coalescing only falls back on `null`/`undefined`, so `""` won and the generic site defaults (`Railway Blog` / `Blog posts from the Railway team`) leaked onto **every post's** `<title>`, `og:title`, `meta description`, and `og:description`.

## Fix

- **`lib/cms/index.ts`** — add a `nonEmptyString()` helper, normalize blank `seoTitle`/`seoDescription` to `null` at the mapping layer (posts + categories). Fixes all `??` consumers at the root: `PostPage`, JSON-LD (`seo-components.tsx`), and category pages.
- **`components/Seo.tsx`** — route the OG image through `buildCMSImageURL(..., { width: 1200 })` at the single `postImage` chokepoint. CMS media URLs become stable gateway URLs; the dynamic `og.railway.com` cards and external escape-hatch URLs pass through untouched.

## Verification

Reproduced and verified against the example post on a local dev server.

Before:
```
<title>Railway Blog</title>
<meta property="og:image" content="https://cms.railway.com/media/Day-03-skills.png"/>
```

After:
```
<title>Skill Issue, Writing /skills to solve agent failures</title>
<meta property="og:image" content="https://cms.railway.com/media/Day-03-skills.png?w=1200&q=90"/>
```

- `tsc --noEmit` clean
- `eslint` clean
- All 91 tests pass

## Note (CMS content, not code)
The example post's `description` field literally contains `"Angelo"` (looks like an author-name typo) and its `seoDescription` is blank, so its card description will read "Angelo". The code now behaves correctly; the content needs a real description entered in the CMS. After deploy, re-scrape via X's Card Validator and re-share on Discord to bust their caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)