### PR TITLE
Add explicit Twitter card tags, og:image dimensions, fix X handle

### DIFF
--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -40,10 +40,12 @@ const config: DefaultSeoProps = {
     type: "website",
     url,
     site_name: title,
-    images: [{ url: image }],
+    images: [{ url: image, width: 1200, height: 630, type: "image/png" }],
   },
   twitter: {
-    handle: "@Railway_App",
+    // Railway's X account is @Railway (x.com/Railway); @Railway_App is stale.
+    site: "@Railway",
+    handle: "@Railway",
     cardType: "summary_large_image",
   },
 }
@@ -72,6 +74,39 @@ const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, ...pro
     ? buildCMSImageURL(rawImage, { width: 1200 })
     : undefined
 
+  // The CMS media behind the OG image, so we can declare its dimensions/type.
+  // Slack and X render the large-image card more reliably when og:image:width/
+  // height are present (and skip a fetch round-trip to detect them).
+  const ogMedia =
+    post?.socialImage?.url === rawImage
+      ? post?.socialImage
+      : post?.featuredImage?.url === rawImage
+        ? post?.featuredImage
+        : null
+  // Every OG image we serve is 1200 wide: the gateway transform caps width at
+  // 1200, and the dynamic og.railway.com card renders at 1200×630. Height is
+  // scaled from the source aspect ratio; the dynamic card defaults to 630.
+  const isDynamicCard = rawImage?.startsWith("https://og.railway.com") ?? false
+  const ogImageMeta =
+    ogMedia?.width && ogMedia?.height
+      ? {
+          width: 1200,
+          height: Math.round((1200 * ogMedia.height) / ogMedia.width),
+          type: ogMedia.mimeType ?? "image/png",
+        }
+      : isDynamicCard
+        ? { width: 1200, height: 630, type: "image/png" }
+        : null
+
+  // next-seo's `twitter` config only emits card/site/creator; Twitter falls
+  // back to og:* for the rest. Mirror title/description/image explicitly so the
+  // card is unambiguous across scrapers (Slack reads these too).
+  const twitterMetaTags = [
+    { name: "twitter:title", content: props.title || title },
+    { name: "twitter:description", content: description },
+    ...(postImage ? [{ name: "twitter:image", content: postImage }] : []),
+  ]
+
   return (
     <>
       <DefaultSeo {...config} />
@@ -83,12 +118,15 @@ const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, ...pro
         // "Multiple meta description tags" on every page.
         description={description}
         canonical={fullUrl}
+        additionalMetaTags={twitterMetaTags}
         // next-seo only emits og:url when an openGraph config is present, so
         // always pass one to keep og:url aligned with the canonical. The
         // article block requires type:"article" or next-seo drops it.
         openGraph={{
           url: fullUrl,
-          ...(postImage != null && { images: [{ url: postImage }] }),
+          ...(postImage != null && {
+            images: [{ url: postImage, ...(ogImageMeta ?? {}) }],
+          }),
           ...(post != null && {
             type: "article",
             article: {

--- a/test/components/Seo.test.tsx
+++ b/test/components/Seo.test.tsx
@@ -96,12 +96,70 @@ describe("SEO head shape", () => {
     const props = mockNextSeoCalls[0] as {
       openGraph?: { type?: string; images?: { url: string }[]; article?: unknown }
     }
+    // The dynamic og.railway.com card renders at a known 1200×630, so we
+    // declare its dimensions/type for Slack/X large-image rendering.
     expect(props.openGraph?.images).toEqual([
-      { url: "https://og.railway.com/api/image?x=1" },
+      {
+        url: "https://og.railway.com/api/image?x=1",
+        width: 1200,
+        height: 630,
+        type: "image/png",
+      },
     ])
     // no post → no article semantics
     expect(props.openGraph?.type).toBeUndefined()
     expect(props.openGraph?.article).toBeUndefined()
+  })
+
+  it("mirrors title/description/image into explicit twitter:* tags", () => {
+    render(
+      <SEO
+        title={post.title}
+        description={post.description}
+        image="https://og.railway.com/api/image?x=1"
+        post={post}
+        currentUrl={postUrl}
+      />
+    )
+
+    const props = mockNextSeoCalls[0] as {
+      additionalMetaTags?: { name: string; content: string }[]
+    }
+    const byName = Object.fromEntries(
+      (props.additionalMetaTags ?? []).map((t) => [t.name, t.content])
+    )
+    expect(byName["twitter:title"]).toBe(post.title)
+    expect(byName["twitter:description"]).toBe(post.description)
+    expect(byName["twitter:image"]).toBe("https://og.railway.com/api/image?x=1")
+  })
+
+  it("declares og:image dimensions from the source social image", () => {
+    render(
+      <SEO
+        image="https://cms.railway.com/media/card.png"
+        post={{
+          ...post,
+          socialImage: {
+            id: "m1",
+            url: "https://cms.railway.com/media/card.png",
+            alt: "",
+            width: 2400,
+            height: 1260,
+            mimeType: "image/png",
+          },
+        }}
+        currentUrl={postUrl}
+      />
+    )
+
+    const props = mockNextSeoCalls[0] as {
+      openGraph?: { images?: { width?: number; height?: number; type?: string }[] }
+    }
+    const img = props.openGraph?.images?.[0]
+    // 2400×1260 scaled to width 1200 → height 630
+    expect(img?.width).toBe(1200)
+    expect(img?.height).toBe(630)
+    expect(img?.type).toBe("image/png")
   })
 
   it("renders no head tags of its own besides JSON-LD (no duplicate description/canonical/title/article)", () => {


### PR DESCRIPTION
Follow-up to #95. Hardens social-card rendering for Slack and X.

## Changes

### 1. Fix the X handle (`@Railway_App` → `@Railway`)
Railway's X account is `@Railway` (x.com/Railway); `@Railway_App` was stale. Updates `twitter:creator` and adds `twitter:site`.

### 2. Explicit `twitter:title` / `twitter:description` / `twitter:image`
next-seo's `twitter` config only emits `twitter:card`/`site`/`creator` — it relies on scrapers falling back to `og:*` for the rest. We now mirror title/description/image into explicit `twitter:*` tags so the card is unambiguous (Slack reads these too).

### 3. Declare `og:image:width` / `height` / `type`
Every OG image we serve is **1200×630** — the imgproxy gateway transform caps width at 1200, and both the dynamic `og.railway.com` card and the default `docs` card render at 1200×630 (verified). Declaring dimensions lets Slack and X render the **large-image** card reliably without a fetch round-trip. Height is scaled from the source aspect ratio when the image is a known CMS media object.

## Rendered output (local, post with a social image)
```
twitter:card        summary_large_image
twitter:site        @Railway
twitter:creator     @Railway
twitter:title       Skill Issue, Writing /skills to solve agent failures
twitter:description How we wrote the Railway Agent skills, ...
twitter:image       https://cms.railway.com/media/Day-03-skills.png?w=1200&q=90
og:image            https://cms.railway.com/media/Day-03-skills.png?w=1200&q=90
og:image:width      1200
og:image:height     630
og:image:type       image/png
```

## Verification
- `tsc --noEmit` clean, `eslint` clean
- 93 tests pass (added: twitter:* mirroring, og:image dimensions from source media)

## Note on Slack
The image-redirect and title/description bugs from #95 are already live-fixed. Any remaining "not unfurling on Slack" is most likely Slack's **cached preview** from before #95 deployed — Slack caches per-URL and won't re-fetch until it expires. Re-sharing the link (or waiting out the cache) will pick up the corrected card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)