### PR TITLE
Pass SVG CMS media through imgproxy untransformed

### DIFF
--- a/lib/cms/image.ts
+++ b/lib/cms/image.ts
@@ -35,6 +35,17 @@ const getCMSHost = (): string | null => {
   }
 }
 
+// imgproxy resizes/reformats raster images; running an SVG through it produces
+// a broken response, so SVGs must be passed through untouched even when served
+// from the CMS gateway.
+const isSVGURL = (url: string): boolean => {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".svg")
+  } catch {
+    return false
+  }
+}
+
 // Only transform first-party CMS media. Everything else (GitHub avatars,
 // /public assets, SVGs, og.railway) is passed through untouched.
 export const isCMSMediaURL = (url: string): boolean => {
@@ -43,7 +54,11 @@ export const isCMSMediaURL = (url: string): boolean => {
 
   try {
     const parsed = new URL(url)
-    return parsed.host === host && parsed.pathname.startsWith("/media/")
+    return (
+      parsed.host === host &&
+      parsed.pathname.startsWith("/media/") &&
+      !isSVGURL(url)
+    )
   } catch {
     return false
   }


### PR DESCRIPTION
Fixes #97

## Problem

`MarkdownContent` runs every image through the imgproxy gateway transforms (`?w=…&format=webp&q=…`). imgproxy resize/reformat produces a broken response for SVGs, so SVG images in blog posts didn't render — e.g. the SVG on [railway-cdn](https://blog.railway.com/p/railway-cdn). Dropping the transform params makes the image load.

## Fix

`isCMSMediaURL` now returns `false` for `.svg` URLs, so both `buildCMSImageURL` and `buildCMSImageSrcSet` pass SVGs through untouched (original `src`, no `srcSet`). SVGs are vector and don't need resizing or format conversion anyway. This covers all callers — markdown body images, featured-post images, and SEO `og:image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)