### PR TITLE
Fix code block syntax highlighting: lowercase fence languages for shiki

### DIFF
--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -16,16 +16,20 @@ export const Code: React.FC<{ children: string; language?: string }> = ({
     null
   )
 
+  // The CMS editor's language picker writes display names into fences
+  // ("TypeScript", "Shell"); shiki ids and aliases are all lowercase.
+  const shikiLanguage = language.toLowerCase()
+
   useAsyncEffect(async () => {
     // Load just this block's grammar: any language shiki bundles works
     // (tsx, sql, diff, ...) and unknown languages reject, leaving the
     // plain <pre> fallback below.
     setMarkupToHighlight(
       await createHighlighter({
-        langs: [language],
+        langs: [shikiLanguage],
         themes: [theme === "light" ? LIGHT_THEME : DARK_THEME],
       }).then((highlighter) =>
-        highlighter.codeToHtml(children, { lang: language, theme: theme === "light" ? LIGHT_THEME : DARK_THEME })
+        highlighter.codeToHtml(children, { lang: shikiLanguage, theme: theme === "light" ? LIGHT_THEME : DARK_THEME })
       )
     )
   }, [theme])


### PR DESCRIPTION
## Problem

Code blocks on published posts (e.g. [/p/feature-flags](https://blog.railway.com/p/feature-flags)) render as plain unhighlighted `<pre>` blocks.

The new CMS Milkdown/Crepe editor's language picker stores CodeMirror **display names** in code fences (` ```TypeScript `, ` ```Shell `) instead of lowercase ids. Shiki's grammar ids and aliases are all lowercase and case-sensitive, so `createHighlighter({ langs: ["TypeScript"] })` rejects and `Code.tsx` stays on its plain-`<pre>` fallback forever.

## Fix

Lowercase the language before handing it to shiki. `"typescript"` and `"shell"` are valid shiki ids/aliases, so this fixes every already-published post on deploy with no data cleanup.

A companion CMS change normalizes fence languages to lowercase on save so newly stored markdown is canonical going forward; this blog-side fix keeps rendering robust regardless of stored casing.

## Verification

- Reproduced the failure with our shiki version: `TypeScript`/`Shell` throw `ShikiError: Language ... is not included in this bundle`; `typescript`/`shell` load fine.
- Stored markdown for the feature-flags post (via `__NEXT_DATA__`) confirmed capitalized fences from the new editor.
- `tsc --noEmit` clean, full jest suite passes (93 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)