### PR TITLE
SEO: Backfill meta descriptions, title tags + verify FAQ schema

### DIFF
--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -1,6 +1,11 @@
 import { MarkdownContent } from "@components/MarkdownContent"
 import { url } from "@components/Seo"
-import { HiddenTableOfContents, extractTableOfContents } from "@lib/seo-components"
+import {
+  HiddenTableOfContents,
+  buildMetaDescription,
+  buildSeoTitle,
+  extractTableOfContents,
+} from "@lib/seo-components"
 import Page from "@layouts/Page"
 import { BlogPost } from "@lib/types"
 import React, { useMemo } from "react"
@@ -41,8 +46,9 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
   return (
     <Page
       seo={{
-        title: post.seoTitle ?? post.title,
-        description: post.seoDescription ?? post.description,
+        title: post.seoTitle ?? buildSeoTitle(post.title),
+        description:
+          post.seoDescription ?? buildMetaDescription(post.description),
         image: ogImage,
         author: authorName,
         post,

--- a/lib/seo-components.tsx
+++ b/lib/seo-components.tsx
@@ -11,6 +11,43 @@ import React from "react"
 export { extractFAQs, extractTableOfContents }
 export type { FAQItem, TableOfContentsItem }
 
+const META_DESCRIPTION_MAX = 160
+const BRAND_SUFFIX = " | Railway Blog"
+
+/**
+ * Produces a meta description that is at most 160 characters, truncated at the
+ * nearest word boundary with an ellipsis when necessary. Strips leading/trailing
+ * whitespace and normalizes internal runs.
+ */
+export const buildMetaDescription = (
+  description: string | null | undefined
+): string | undefined => {
+  const text = (description ?? "").replace(/\s+/g, " ").trim()
+  if (!text) return undefined
+  if (text.length <= META_DESCRIPTION_MAX) return text
+
+  // Leave room for the trailing "…" (single char).
+  const truncated = text.slice(0, META_DESCRIPTION_MAX - 1)
+  const lastSpace = truncated.lastIndexOf(" ")
+  const clean = lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated
+
+  return `${clean}…`
+}
+
+/**
+ * Appends " | Railway Blog" to a title unless the title already contains
+ * "Railway" (case-insensitive), to avoid doubling up on CMS-authored titles
+ * that already include branding.
+ */
+export const buildSeoTitle = (
+  title: string | null | undefined
+): string | undefined => {
+  const text = (title ?? "").trim()
+  if (!text) return undefined
+  if (/railway/i.test(text)) return text
+  return `${text}${BRAND_SUFFIX}`
+}
+
 export const generateBlogPostSchema = (post: BlogPost, url: string): object => {
   const image = post.socialImage?.url ?? post.featuredImage?.url
   const authorSchema =
@@ -27,7 +64,8 @@ export const generateBlogPostSchema = (post: BlogPost, url: string): object => {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: post.title,
-    description: post.seoDescription ?? post.description,
+    description:
+      post.seoDescription ?? buildMetaDescription(post.description),
     image: image ? [image] : undefined,
     datePublished: post.publishedAt,
     dateModified: post.updatedAt,

--- a/pages/[category].tsx
+++ b/pages/[category].tsx
@@ -8,6 +8,7 @@ import {
   getCategoryRouteSlug,
   getPostsByCategorySlug,
 } from "@lib/cms"
+import { buildSeoTitle } from "@lib/seo-components"
 import { BlogCategory, BlogPost } from "@lib/types"
 import { GetStaticPaths, GetStaticProps, NextPage } from "next"
 
@@ -27,7 +28,9 @@ const CategoryPage: NextPage<Props> = ({
       seo={{
         title:
           category?.seoTitle ??
-          `${category ? getCategoryLabel(category) : "Blog"} - Railway Blog`,
+          buildSeoTitle(
+            category ? getCategoryLabel(category) : "Blog"
+          ),
         description: category?.seoDescription ?? category?.description ?? undefined,
         // The canonical is derived from the category, so the legacy /guide
         // alias canonicalizes to /guides instead of duplicating it.

--- a/test/seo-components.test.ts
+++ b/test/seo-components.test.ts
@@ -1,0 +1,69 @@
+import { buildMetaDescription, buildSeoTitle } from "../lib/seo-components"
+
+describe("buildMetaDescription", () => {
+  it("returns undefined for null input", () => {
+    expect(buildMetaDescription(null)).toBeUndefined()
+  })
+
+  it("returns undefined for empty string", () => {
+    expect(buildMetaDescription("")).toBeUndefined()
+  })
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(buildMetaDescription("   ")).toBeUndefined()
+  })
+
+  it("returns the description unchanged when under 160 chars", () => {
+    const short = "Deploy your app to Railway in seconds."
+    expect(buildMetaDescription(short)).toBe(short)
+  })
+
+  it("returns the description unchanged at exactly 160 chars", () => {
+    const exact = "a".repeat(160)
+    expect(buildMetaDescription(exact)).toBe(exact)
+  })
+
+  it("truncates at the nearest word boundary with an ellipsis", () => {
+    const long =
+      "Railway is a modern cloud platform that makes it easy to deploy your applications, databases, and infrastructure. It provides automatic scaling, monitoring, and more for production workloads."
+    const result = buildMetaDescription(long)!
+    expect(result.length).toBeLessThanOrEqual(160)
+    expect(result).toMatch(/…$/)
+    // Must not break mid-word
+    expect(result.slice(0, -1)).not.toMatch(/\S$/)
+  })
+
+  it("normalizes internal whitespace runs", () => {
+    expect(buildMetaDescription("Deploy  your   app")).toBe("Deploy your app")
+  })
+})
+
+describe("buildSeoTitle", () => {
+  it("returns undefined for null input", () => {
+    expect(buildSeoTitle(null)).toBeUndefined()
+  })
+
+  it("returns undefined for empty string", () => {
+    expect(buildSeoTitle("")).toBeUndefined()
+  })
+
+  it("appends ' | Railway Blog' to a plain title", () => {
+    expect(buildSeoTitle("How to Deploy a Node App")).toBe(
+      "How to Deploy a Node App | Railway Blog"
+    )
+  })
+
+  it("does not double-append when the title already contains 'Railway'", () => {
+    expect(buildSeoTitle("Why Railway is Great")).toBe("Why Railway is Great")
+  })
+
+  it("is case-insensitive when checking for Railway", () => {
+    expect(buildSeoTitle("Deploy on RAILWAY")).toBe("Deploy on RAILWAY")
+  })
+
+  it("trims surrounding whitespace", () => {
+    expect(buildSeoTitle("  Hello World  ")).toBe(
+      "Hello World | Railway Blog"
+    )
+  })
+})


### PR DESCRIPTION
## What

Backfill missing meta descriptions and title tags for AEO across blog.railway.com. Verifies FAQPage JSON-LD schema is already wired.

## Changes

### Meta description backfill (`buildMetaDescription`)
When `seoDescription` is null in the CMS, the fallback `post.description` is now truncated to **≤160 characters** at the nearest word boundary (with trailing `…`). Whitespace is normalized. Applied in:
- `PostPage.tsx` — individual blog posts
- `seo-components.tsx` — BlogPosting JSON-LD schema

### Title tag backfill (`buildSeoTitle`)
When `seoTitle` is null, appends **` | Railway Blog`** to the post/category title for brand presence in SERPs. Skips appending when the title already contains "Railway" (case-insensitive) to avoid doubling. Applied in:
- `PostPage.tsx` — individual blog posts
- `[category].tsx` — category listing pages

### FAQPage JSON-LD ✅ Already wired
The existing pipeline (`extractFAQs` → `generateFAQSchema` → `Seo.tsx` injection) already emits FAQPage JSON-LD on any post whose content has Q&A-style h2/h3 headings ending in `?`. No changes needed — confirmed working.

## Tests
Added `test/seo-components.test.ts` covering both utilities (truncation, word boundary, branding, edge cases).

## Nothing visual
Pure markup — no UI changes.