### PR TITLE
Emit post content in llms-blog.md

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -176,6 +176,61 @@ export const extractTableOfContents = (
 }
 
 /**
+ * Demotes headings by two levels (H1→H3, …, capped at H6) so a post body can
+ * nest under an existing H1/H2 hierarchy (e.g. llms-blog.md's
+ * `# Category` → `## Blog:` structure). Fenced code is left untouched: a bash
+ * comment like "# install" is not a heading.
+ */
+export const demoteHeadings = (content: string) => {
+  let inFence = false
+
+  return content
+    .split(/\r?\n/)
+    .map((line) => {
+      if (/^\s*```/.test(line)) {
+        inFence = !inFence
+        return line
+      }
+
+      if (inFence) return line
+
+      return line.replace(
+        /^(#{1,6})(\s)/,
+        (_, hashes: string, space: string) =>
+          `${"#".repeat(Math.min(hashes.length + 2, 6))}${space}`
+      )
+    })
+    .join("\n")
+}
+
+/**
+ * Truncates markdown to roughly `maxWords`, cutting at a paragraph boundary
+ * so we never emit half a sentence. If the cut leaves a code fence open, it
+ * is closed so following markdown survives. A truncation notice is appended
+ * whenever content was dropped.
+ */
+export const truncateMarkdown = (content: string, maxWords: number) => {
+  const paragraphs = content.split(/\n{2,}/)
+  const kept: string[] = []
+  let words = 0
+
+  for (const paragraph of paragraphs) {
+    words += paragraph.split(/\s+/).filter(Boolean).length
+
+    if (words > maxWords && kept.length > 0) {
+      const fences = kept.join("\n\n").match(/^\s*```/gm)?.length ?? 0
+      if (fences % 2 === 1) kept.push("```")
+      kept.push("*[Content truncated. Read the full post at the link above.]*")
+      break
+    }
+
+    kept.push(paragraph)
+  }
+
+  return kept.join("\n\n")
+}
+
+/**
  * Questions may only come from h2/h3 headings or callouts ending in "?";
  * body text can only ever answer a pending question. Letting arbitrary
  * paragraphs become questions turns rhetorical prose into fabricated

--- a/pages/llms-blog.md/index.tsx
+++ b/pages/llms-blog.md/index.tsx
@@ -1,9 +1,15 @@
 import { getBlogLink, getPosts } from "@lib/cms"
-import { extractTableOfContents } from "@lib/markdown"
+import {
+  demoteHeadings,
+  extractTableOfContents,
+  truncateMarkdown,
+} from "@lib/markdown"
 import { BlogPost } from "@lib/types"
 import { GetServerSideProps } from "next"
 
 const ROOT_URL = "https://blog.railway.com"
+
+const MAX_CONTENT_WORDS = 1500
 
 const groupPostsByCategory = (posts: BlogPost[]) =>
   posts.reduce(
@@ -25,7 +31,8 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   const header = `# Railway Blog Content
 
 This document contains all blog posts from the Railway blog, organized by category.
-Each post includes its metadata, description, and key points from the content.
+Each post includes its metadata, description, key points, and content
+(truncated for very long posts).
 
 Last updated: ${new Date().toISOString().split("T")[0]}
 
@@ -41,6 +48,10 @@ Last updated: ${new Date().toISOString().split("T")[0]}
           .filter((item) => item.level <= 2)
           .map((item) => `- ${item.text}`)
           .join("\n")
+        const body = truncateMarkdown(
+          demoteHeadings(post.content ?? ""),
+          MAX_CONTENT_WORDS
+        )
 
         return `## Blog: ${post.title}
 
@@ -51,7 +62,7 @@ Last updated: ${new Date().toISOString().split("T")[0]}
 ${post.description}
 
 ${headers ? `\n### Key points:\n${headers}\n` : ""}
-
+${body ? `\n${body}\n` : ""}
 ---
 `
       })

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,7 +1,9 @@
 import {
+  demoteHeadings,
   extractFAQs,
   extractTableOfContents,
   stripMarkdown,
+  truncateMarkdown,
 } from "../lib/markdown"
 
 describe("extractFAQs", () => {
@@ -164,5 +166,71 @@ describe("extractTableOfContents", () => {
       "## Real heading\n\n```bash\n# install dependencies\nyarn install\n```"
     )
     expect(toc.map((item) => item.id)).toEqual(["real-heading"])
+  })
+})
+
+describe("demoteHeadings", () => {
+  it("demotes headings by two levels", () => {
+    expect(demoteHeadings("# Title\n## Section\n### Sub")).toBe(
+      "### Title\n#### Section\n##### Sub"
+    )
+  })
+
+  it("caps demotion at h6", () => {
+    expect(demoteHeadings("##### Deep\n###### Deeper")).toBe(
+      "###### Deep\n###### Deeper"
+    )
+  })
+
+  it("does not demote comments inside fenced code blocks", () => {
+    const content = "# Real\n\n```bash\n# install\nnpm i\n```\n\n## Also real"
+    expect(demoteHeadings(content)).toBe(
+      "### Real\n\n```bash\n# install\nnpm i\n```\n\n#### Also real"
+    )
+  })
+
+  it("leaves non-heading text untouched", () => {
+    const content = "Plain paragraph\n#hashtag without space"
+    expect(demoteHeadings(content)).toBe(content)
+  })
+})
+
+describe("truncateMarkdown", () => {
+  it("returns short content unchanged", () => {
+    const content = "First paragraph.\n\nSecond paragraph."
+    expect(truncateMarkdown(content, 100)).toBe(content)
+  })
+
+  it("cuts at a paragraph boundary and appends a truncation notice", () => {
+    const content = ["one two three", "four five six", "seven eight nine"].join(
+      "\n\n"
+    )
+    const result = truncateMarkdown(content, 6)
+    expect(result).toContain("one two three")
+    expect(result).toContain("four five six")
+    expect(result).not.toContain("seven")
+    expect(result).toMatch(/Content truncated/)
+  })
+
+  it("always keeps the first paragraph even when it exceeds the budget", () => {
+    const first = Array(20).fill("word").join(" ")
+    const result = truncateMarkdown(`${first}\n\nsecond paragraph`, 5)
+    expect(result).toContain(first)
+    expect(result).not.toContain("second paragraph")
+  })
+
+  it("closes a code fence left open by the cut", () => {
+    const content = [
+      "intro paragraph here",
+      "```bash\necho hi",
+      "echo bye\n```",
+      Array(50).fill("word").join(" "),
+    ].join("\n\n")
+    // Budget allows the intro and the fence opener but not the fence closer.
+    const result = truncateMarkdown(content, 6)
+    expect(result).toContain("```bash")
+    const fences = result.match(/^\s*```/gm)?.length ?? 0
+    expect(fences % 2).toBe(0)
+    expect(result).toMatch(/Content truncated/)
   })
 })


### PR DESCRIPTION
## Problem
`pages/llms-blog.md/index.tsx` fetches every post with `includeContent: true` but never emits the content — each post renders only title/date/slug/link, description, and an H2 list (~516 bytes/post across 209 posts). The file most cited by LLM crawlers contains nothing quotable.

## Fix
Emit each post's actual content after its metadata block. Content is already in memory, so this adds zero CMS calls; cache headers are unchanged and the file still auto-updates on every render like `sitemap.xml`.

Two helpers added to `lib/markdown.ts`:
- `demoteHeadings` — shifts post-body headings down two levels (H1→H3, capped at H6) so they nest under the file's `# Category` → `## Blog:` hierarchy; lines inside fenced code blocks are untouched
- `truncateMarkdown` — caps content at ~1,500 words, cutting at a paragraph boundary and closing any code fence the cut leaves open, with a truncation notice pointing at the post link

## Testing
- 8 new jest tests covering demotion (levels, H6 cap, fenced-code skip) and truncation (boundary cut, notice, first-paragraph floor, fence closing)
- `jest`, `tsc --noEmit`, and `eslint` all pass