### PR TITLE
feat(seo): serve /llms.txt index linking llms-blog.md, rss, and all posts

### DIFF
--- a/pages/llms.txt/index.tsx
+++ b/pages/llms.txt/index.tsx
@@ -1,0 +1,73 @@
+import { getBlogLink, getPosts } from "@lib/cms"
+import { BlogPost } from "@lib/types"
+import { GetServerSideProps } from "next"
+
+const ROOT_URL = "https://blog.railway.com"
+
+const SUMMARY =
+  "Blog posts from the Railway team: deployment tutorials, deep engineering " +
+  "adventures, product updates, and how the team works and builds Railway."
+
+const groupPostsByCategory = (posts: BlogPost[]) =>
+  posts.reduce(
+    (acc, post) => {
+      const category = post.category?.title || "Uncategorized"
+      if (!acc[category]) {
+        acc[category] = []
+      }
+      acc[category].push(post)
+      return acc
+    },
+    {} as Record<string, BlogPost[]>
+  )
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const posts = await getPosts()
+  const postsByCategory = groupPostsByCategory(posts)
+
+  const header = `# Railway Blog
+
+> ${SUMMARY}
+
+The full text of every post is available in a single file at
+${ROOT_URL}/llms-blog.md. An RSS feed of featured posts and guides is
+available at ${ROOT_URL}/rss.xml.
+
+`
+
+  const categoryContents = Object.entries(postsByCategory).map(
+    ([category, categoryPosts]) => {
+      const links = categoryPosts.map((post) => {
+        const link = ROOT_URL + getBlogLink(post.slug)
+        return post.description
+          ? `- [${post.title}](${link}): ${post.description}`
+          : `- [${post.title}](${link})`
+      })
+
+      return `## ${category}
+
+${links.join("\n")}
+`
+    }
+  )
+
+  res.setHeader("Content-Type", "text/plain; charset=utf-8")
+  // Every render lists all posts from the CMS; let shared caches absorb
+  // repeat crawler traffic.
+  res.setHeader(
+    "Cache-Control",
+    "public, s-maxage=3600, stale-while-revalidate=86400"
+  )
+  res.write(header + categoryContents.join("\n"))
+  res.end()
+
+  return {
+    props: {},
+  }
+}
+
+const GenerateTextFile = () => {
+  return null
+}
+
+export default GenerateTextFile


### PR DESCRIPTION
## Problem
`blog.railway.com/llms.txt` returns a 404. The blog's LLM-readable content dump exists only at `/llms-blog.md`, which agents/crawlers probing the standard `/llms.txt` discovery path never find (it's only linked from railway.com's llms.txt hub).

## Change
Add `pages/llms.txt/index.tsx` (same SSR text-route pattern as `llms-blog.md`) serving an [llms.txt-format](https://llmstxt.org) index:
- Links the single-file full-content dump at `/llms-blog.md`
- Links the RSS feed at `/rss.xml`
- Lists every published post by category as `- [title](url): description`

Served as `text/plain` with the same `s-maxage=3600, stale-while-revalidate=86400` caching as the existing dump.

## Validation
- `tsc --pretty --noEmit` passes