### PR TITLE
feat(aeo): .md twins for individual blog posts

### DIFF
--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -18,6 +18,7 @@ export interface Props extends NextSeoProps {
   post?: BlogPost
   content?: string | null
   currentUrl?: string
+  alternateMarkdownHref?: string
 }
 
 // Raw JSON.stringify output is unsafe inside a <script>: a CMS-authored
@@ -50,7 +51,7 @@ const config: DefaultSeoProps = {
   },
 }
 
-const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, ...props }) => {
+const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, alternateMarkdownHref, ...props }) => {
   const description = props.description || config.description
   const fullUrl = currentUrl || url
 
@@ -159,6 +160,10 @@ const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, ...pro
             type="application/ld+json"
             dangerouslySetInnerHTML={{ __html: serializeSchema(faqSchema) }}
           />
+        )}
+
+        {alternateMarkdownHref && (
+          <link rel="alternate" type="text/markdown" href={alternateMarkdownHref} />
         )}
       </Head>
     </>

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -54,6 +54,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
         post,
         content: post.content,
         currentUrl,
+        alternateMarkdownHref: `/p/${post.slug}.md`,
       }}
     >
       <div className="mt-10 mb-5 px-5 md:px-8 mx-auto">

--- a/pages/p/[slug].md/index.tsx
+++ b/pages/p/[slug].md/index.tsx
@@ -1,0 +1,86 @@
+import { getPostBySlug } from "@lib/cms"
+import { GetServerSideProps } from "next"
+
+const ROOT_URL = "https://blog.railway.com"
+
+/**
+ * Markdown twin of /p/{slug}. Serves the post's full content as
+ * text/markdown with YAML front-matter so LLMs and markdown-preferring
+ * clients get the same payload the HTML page serves.
+ */
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  res,
+}) => {
+  const slug = typeof params?.slug === "string" ? params.slug : null
+
+  if (!slug) {
+    res.statusCode = 404
+    res.setHeader("Content-Type", "text/plain; charset=utf-8")
+    res.end("Post not found")
+    return { props: {} }
+  }
+
+  const post = await getPostBySlug(slug)
+
+  if (!post) {
+    res.statusCode = 404
+    res.setHeader("Content-Type", "text/plain; charset=utf-8")
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=60, s-maxage=60, stale-while-revalidate=300"
+    )
+    res.end("Post not found")
+    return { props: {} }
+  }
+
+  const url = `${ROOT_URL}/p/${post.slug}`
+  const authors = post.authors.map((a) => a.name).filter(Boolean)
+
+  const yamlQuote = (value: string) =>
+    `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`
+
+  const parts: string[] = []
+
+  parts.push("---")
+  parts.push(`title: ${yamlQuote(post.title)}`)
+  if (post.description) {
+    parts.push(`description: ${yamlQuote(post.description)}`)
+  }
+  parts.push(`date: ${post.publishedAt}`)
+  if (authors.length > 0) {
+    parts.push(`authors: [${authors.map(yamlQuote).join(", ")}]`)
+  }
+  if (post.category) {
+    parts.push(`category: ${yamlQuote(post.category.title)}`)
+  }
+  parts.push(`url: ${url}`)
+  parts.push("---")
+  parts.push("")
+  parts.push(`# ${post.title}`)
+  parts.push("")
+
+  if (post.content) {
+    parts.push(post.content)
+    parts.push("")
+  }
+
+  parts.push(`---`)
+  parts.push("")
+  parts.push(`Open this post in a browser: ${url}`)
+  parts.push("")
+
+  res.setHeader("Content-Type", "text/markdown; charset=utf-8")
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
+  )
+  res.write(parts.join("\n"))
+  res.end()
+
+  return { props: {} }
+}
+
+const MarkdownTwin = () => null
+
+export default MarkdownTwin


### PR DESCRIPTION
## What

Adds markdown twin pages for every blog post at `/p/{slug}.md`, completing AEO G06 for the blog repo.

### Changes

- **`pages/p/[slug].md/index.tsx`** — New SSR route that serves the full post content as `text/markdown` with YAML front-matter (title, description, date, authors, category, canonical URL). Returns 404 for unknown slugs with a short cache lease.
- **`components/Seo.tsx`** — Accept optional `alternateMarkdownHref` prop, emit `<link rel="alternate" type="text/markdown">` in `<Head>` when set.
- **`layouts/PostPage.tsx`** — Pass `alternateMarkdownHref: /p/{slug}.md` to the SEO component for every post page.

### Why

AI answer engines and LLM crawlers that send `Accept: text/markdown` (or follow `rel=alternate` discovery) can now get clean markdown for every blog post instead of parsing HTML. Previously, `/p/{slug}.md` returned 404.

The pattern mirrors what the mono repo already does for changelog entries, deploy categories, and agents.