### PR TITLE
fix(seo): route schema image through CMS gateway + PNG publisher logo (G15)

### DIFF
--- a/lib/seo-components.tsx
+++ b/lib/seo-components.tsx
@@ -1,4 +1,5 @@
 import { getCategoryPath } from "@lib/cms"
+import { buildCMSImageURL } from "@lib/cms/image"
 import {
   extractFAQs,
   extractTableOfContents,
@@ -60,13 +61,17 @@ export const generateBlogPostSchema = (post: BlogPost, url: string): object => {
           }))
         : undefined
 
+  // Route schema image through the CMS gateway so crawlers get a stable
+  // CDN-cached 200 instead of a 307 → short-lived signed URL.
+  const schemaImage = image ? buildCMSImageURL(image, { width: 1200 }) : undefined
+
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: post.title,
     description:
       post.seoDescription ?? buildMetaDescription(post.description),
-    image: image ? [image] : undefined,
+    image: schemaImage ? [schemaImage] : undefined,
     datePublished: post.publishedAt,
     dateModified: post.updatedAt,
     author: authorSchema,
@@ -75,7 +80,7 @@ export const generateBlogPostSchema = (post: BlogPost, url: string): object => {
       name: "Railway",
       logo: {
         "@type": "ImageObject",
-        url: "https://blog.railway.com/railway.svg",
+        url: "https://railway.com/brand/logo-dark.png",
       },
     },
     mainEntityOfPage: {


### PR DESCRIPTION
## What

Fix two structured-data issues from G15.

### Changes

1. **Schema image 307 → stable CDN URL** — `generateBlogPostSchema` was passing raw CMS URLs (`cms.railway.com/media/...`) into the BlogPosting `image` field. These 307-redirect to 5-minute signed storage URLs that expire before Google can crawl them. Now routed through `buildCMSImageURL` (same as the OG image path) for a stable, CDN-cached 200.

2. **Publisher logo SVG → PNG** — `railway.svg` → `railway.com/brand/logo-dark.png`. Google rich results require raster logos; SVGs are ignored.

### Risk
Low — metadata-only change. No visible page content affected.