### PR TITLE
fix: use real dates for homepage and category lastmod in sitemap

### DIFF
--- a/pages/sitemap.xml/index.tsx
+++ b/pages/sitemap.xml/index.tsx
@@ -4,10 +4,20 @@ import {
   getCategoryPath,
   getPosts,
 } from "@lib/cms"
+import { BlogPost } from "@lib/types"
 import { GetServerSideProps } from "next"
 import { getServerSideSitemap } from "next-sitemap"
 
 const ROOT_URL = "https://blog.railway.com"
+
+/** Return the most recent updatedAt ISO string across the given posts. */
+const latestUpdate = (posts: BlogPost[]): string | undefined => {
+  if (posts.length === 0) return undefined
+  return posts.reduce((latest, post) => {
+    const d = post.updatedAt || post.publishedAt
+    return d > latest ? d : latest
+  }, posts[0].updatedAt || posts[0].publishedAt)
+}
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   ctx.res.setHeader(
@@ -16,22 +26,33 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   )
 
   const [posts, categories] = await Promise.all([getPosts(), getCategories()])
-  const now = new Date().toISOString()
 
   const postPaths = posts.map((post) => ({
     loc: ROOT_URL + getBlogLink(post.slug),
     lastmod: new Date(post.updatedAt || post.publishedAt).toISOString(),
   }))
 
-  const categoryPaths = categories.map((category) => ({
-    loc: ROOT_URL + getCategoryPath(category),
-    lastmod: now,
-  }))
+  // Use the most recent post update for each category instead of new Date()
+  const categoryPaths = categories.map((category) => {
+    const categoryPosts = posts.filter(
+      (post) => post.category?.slug === category.slug
+    )
+    const lastmod = latestUpdate(categoryPosts)
+    return {
+      loc: ROOT_URL + getCategoryPath(category),
+      ...(lastmod && { lastmod: new Date(lastmod).toISOString() }),
+    }
+  })
+
+  // Homepage lastmod = most recent post update across all posts
+  const homepageLastmod = latestUpdate(posts)
 
   const fields = [
     {
       loc: ROOT_URL,
-      lastmod: now,
+      ...(homepageLastmod && {
+        lastmod: new Date(homepageLastmod).toISOString(),
+      }),
     },
     ...categoryPaths,
     ...postPaths,


### PR DESCRIPTION
## Problem
Homepage and category page entries in the sitemap use `new Date()` per request, fabricating lastmod timestamps. This trains crawlers to distrust the entire sitemap.

## Changes
- **Homepage**: `lastmod` = `max(post.updatedAt)` across all posts
- **Category pages**: `lastmod` = `max(post.updatedAt)` for posts in that category; omitted if no posts
- **Individual posts**: Unchanged (already using `post.updatedAt || post.publishedAt`)

## Impact
Restores crawl-priority signals by only emitting real content-change dates.