### PR TITLE
fix: render CMS-shaped YouTube embeds

### DIFF
--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -64,6 +64,38 @@ const isEmbedLink = (href: string | null | undefined, label: string) =>
           (extractYoutubeId(href) != null || isTemplateURL(href))))
   )
 
+const isWhitespaceHastText = (node: any) =>
+  node?.type === "text" && !String(node.value ?? "").trim()
+
+// The CMS Milkdown editor serializes a YouTube embed as `[caption](watch-url)`
+// (or `[](watch-url)` when uncaptioned) in a paragraph of its own — never as
+// `[url](url)`. Only a paragraph-level pass can tell that shape apart from a
+// labeled prose link mid-sentence (marathon-tv-app's [*Shogun*]), so mark the
+// link here and let the `a` renderer read the mark. Must run AFTER
+// rehypeSanitize, which strips unknown data attributes.
+const markStandaloneYoutubeLinks = () => (tree: any) => {
+  const walk = (node: any) => {
+    node?.children?.forEach(walk)
+
+    if (node?.tagName !== "p") return
+
+    const children = (node.children ?? []).filter(
+      (child: any) => !isWhitespaceHastText(child)
+    )
+    const link = children.length === 1 ? children[0] : null
+    const href = link?.tagName === "a" ? link.properties?.href : null
+
+    if (typeof href === "string" && extractYoutubeId(href)) {
+      link.properties.dataYoutubeEmbed = "true"
+    }
+  }
+
+  walk(tree)
+}
+
+const isMarkedYoutubeEmbed = (node: any) =>
+  Boolean(node?.properties?.dataYoutubeEmbed)
+
 // A tweet link is only an embed when its label is the URL itself: that shape
 // covers both `[url](url)` and bare GFM autolinks, i.e. what was an embed
 // block before the CMS migration. Labeled tweet links stay inline links.
@@ -85,7 +117,11 @@ const hasBlockMarkdownChild = (node: any) =>
       if (child?.tagName === "a") {
         const href = child.properties?.href
         const label = getHastText(child)
-        return isEmbedLink(href, label) || Boolean(getTweetEmbedId(href, label))
+        return (
+          isEmbedLink(href, label) ||
+          isMarkedYoutubeEmbed(child) ||
+          Boolean(getTweetEmbedId(href, label))
+        )
       }
 
       return false
@@ -160,7 +196,7 @@ const MarkdownSegmentRenderer: React.FC<{
 
       return <p className="mb-4 leading-8 text-gray-800">{children}</p>
     },
-    a: ({ href, children }) => {
+    a: ({ href, children, node }) => {
       const label = getNodeText(children)
 
       if (isVideoURL(href)) {
@@ -187,8 +223,13 @@ const MarkdownSegmentRenderer: React.FC<{
         )
       }
 
-      const youtubeId = href && label === href ? extractYoutubeId(href) : null
+      const youtubeId =
+        href && (label === href || isMarkedYoutubeEmbed(node))
+          ? extractYoutubeId(href)
+          : null
       if (youtubeId) {
+        const caption = label !== href ? getMediaCaption(label) : null
+
         return (
           <span
             className="block my-8"
@@ -198,9 +239,14 @@ const MarkdownSegmentRenderer: React.FC<{
               className="w-full rounded-lg"
               src={`https://youtube.com/embed/${youtubeId}`}
               height={550}
-              title={label || "YouTube video"}
+              title={caption || "YouTube video"}
               allowFullScreen
             />
+            {caption && (
+              <span className="block text-gray-600 mt-3 text-sm">
+                {caption}
+              </span>
+            )}
           </span>
         )
       }
@@ -342,7 +388,7 @@ const MarkdownSegmentRenderer: React.FC<{
     <ReactMarkdown
       components={components}
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSanitize]}
+      rehypePlugins={[rehypeSanitize, markStandaloneYoutubeLinks]}
       skipHtml
     >
       {content}

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -236,9 +236,8 @@ const MarkdownSegmentRenderer: React.FC<{
             data-markdown-block="true"
           >
             <iframe
-              className="w-full rounded-lg"
+              className="w-full aspect-video rounded-lg"
               src={`https://youtube.com/embed/${youtubeId}`}
-              height={550}
               title={caption || "YouTube video"}
               allowFullScreen
             />

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -111,6 +111,49 @@ describe("MarkdownContent embed links", () => {
     expect(container.querySelector("p")).toBeNull()
   })
 
+  // The CMS Milkdown editor serializes YouTube embeds as [caption](watch-url)
+  // in a paragraph of their own (how-to-make-viral-commercial), never as
+  // [url](url) — a standalone labeled link is an embed, not a prose link.
+  it("renders a standalone captioned YouTube link as a block embed with caption", () => {
+    const url = "https://www.youtube.com/watch?v=HtmvvzNphB8"
+    const { container, getByText } = render(
+      <MarkdownContent
+        content={`Intro paragraph.\n\n[The peaceful way to ship software](${url})`}
+      />
+    )
+
+    const iframe = container.querySelector("iframe")
+    expect(iframe?.getAttribute("src")).toBe(
+      "https://youtube.com/embed/HtmvvzNphB8"
+    )
+    expect(getByText("The peaceful way to ship software")).toBeTruthy()
+    expect(container.querySelector(`a[href="${url}"]`)).toBeNull()
+    expect(container.querySelectorAll("p").length).toBe(1)
+  })
+
+  // Uncaptioned CMS embeds serialize as [](watch-url): an empty-label link
+  // that renders as nothing at all without the standalone-paragraph rule.
+  it("renders a standalone empty-label YouTube link as an uncaptioned embed", () => {
+    const url = "https://www.youtube.com/watch?v=HtmvvzNphB8"
+    const { container } = render(<MarkdownContent content={`[](${url})`} />)
+
+    const iframe = container.querySelector("iframe")
+    expect(iframe?.getAttribute("src")).toBe(
+      "https://youtube.com/embed/HtmvvzNphB8"
+    )
+    expect(iframe?.getAttribute("title")).toBe("YouTube video")
+    expect(container.querySelector("p")).toBeNull()
+  })
+
+  it("keeps a standalone-paragraph labeled YouTube link inside a blockquote as an embed", () => {
+    const url = "https://www.youtube.com/watch?v=HtmvvzNphB8"
+    const { container } = render(
+      <MarkdownContent content={`> [Watch the keynote](${url})`} />
+    )
+
+    expect(container.querySelector("blockquote iframe")).not.toBeNull()
+  })
+
   // Notion exported video blocks as [caption](file.mp4) — a label must NOT
   // demote them to inline links (46 captioned video embeds in the corpus).
   it("keeps a labeled video link as a block player with the label as caption", () => {


### PR DESCRIPTION
## Problem

YouTube embeds authored in the CMS render as inline text links (see the four videos in [how-to-make-viral-commercial](https://blog.railway.com/p/how-to-make-viral-commercial)).

The renderer only produced an iframe when a link's label was the URL itself (`[url](url)` — the Notion-export shape). But the CMS Milkdown YouTube block serializes embeds as `[caption](watch-url)` — or `[](watch-url)` when uncaptioned — in a paragraph of their own, never `[url](url)`. Re-saving an old post in the CMS also rewrites legacy `[url](url)` embeds into the new shape, silently breaking them.

## Fix

A rehype pass marks a YouTube link that is the **sole child of its paragraph** (the exact shape the CMS emits; it runs after `rehypeSanitize`, which strips unknown data attributes). The link renderer turns marked links into block embeds with the label as a caption below the player, mirroring how captioned video files already render. Mid-sentence labeled links stay inline.

## Verification

- Scanned all 210 production posts: every broken embed is a standalone-paragraph link; every legitimate prose YouTube link (marathon-tv-app's *Shogun*, how-we-write-changelogs, gcp-incidents, launch-week-01-regions, authorizer) is mid-sentence. The rule fixes all of the former and touches none of the latter.
- New tests for the captioned, empty-label, and blockquote shapes; existing inline-link regression tests unchanged and passing.
- `jest` + `tsc` clean (the pre-existing `seo-components` word-boundary failure also fails on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)