### PR TITLE
Align blog typography with the brand system

### DIFF
--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -179,14 +179,14 @@ const MarkdownSegmentRenderer: React.FC<{
     h1: ({ children }) =>
       renderHeading(
         "h2",
-        "text-4xl font-bold leading-snug mt-16 mb-8",
+        "text-h1 font-semibold mt-16 mb-8",
         slugger,
         children
       ),
     h2: ({ children }) =>
-      renderHeading("h2", "text-h2 font-bold mt-10 mb-5", slugger, children),
+      renderHeading("h2", "text-h2 font-semibold mt-10 mb-5", slugger, children),
     h3: ({ children }) =>
-      renderHeading("h3", "text-xl font-bold mt-6 mb-4", slugger, children),
+      renderHeading("h3", "text-h3 font-semibold mt-6 mb-4", slugger, children),
     p: ({ children, node }) => {
       const childArray = React.Children.toArray(children)
 
@@ -194,7 +194,7 @@ const MarkdownSegmentRenderer: React.FC<{
         return <>{children}</>
       }
 
-      return <p className="mb-4 leading-8 text-gray-800">{children}</p>
+      return <p className="mb-4 text-gray-800">{children}</p>
     },
     a: ({ href, children, node }) => {
       const label = getNodeText(children)
@@ -328,7 +328,7 @@ const MarkdownSegmentRenderer: React.FC<{
         {children}
       </ol>
     ),
-    li: ({ children }) => <li className="mb-2 leading-8">{children}</li>,
+    li: ({ children }) => <li className="mb-2">{children}</li>,
     table: ({ children }) => (
       <div className="my-8 overflow-x-auto">
         <table className="w-full border-collapse text-left text-sm">

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -96,11 +96,13 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
             <time dateTime={post.publishedAt}>{formattedDate}</time>
           </div>
 
-          <header className="mt-5 mb-16 max-w-[736px] mx-auto">
-            <h1 className="text-6xl font-medium font-serif">{post.title}</h1>
+          <header className="mt-5 mb-10 max-w-[736px] mx-auto">
+            <h1 className="font-serif font-semibold text-[40px] leading-[50px] tracking-[-0.8px] sm:text-[48px] sm:leading-[60px] sm:tracking-[-0.96px] md:text-display-h1">
+              {post.title}
+            </h1>
           </header>
 
-          <section className="max-w-[736px] mx-auto text-base sm:text-lg leading-8">
+          <section className="max-w-[736px] mx-auto text-base sm:text-lg">
             <HiddenTableOfContents items={tableOfContents} />
             <MarkdownContent content={post.content ?? ""} />
           </section>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,13 +4,21 @@ import "@styles/globals.css"
 import { ThemeProvider } from "next-themes"
 import type { AppProps } from "next/app"
 import Head from "next/head"
-import { Inter, IBM_Plex_Serif } from "next/font/google"
+import { Inter, IBM_Plex_Serif, JetBrains_Mono } from "next/font/google"
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans",
+})
 const ibmPlexSerif = IBM_Plex_Serif({
   weight: ["400", "500", "600", "700"],
   subsets: ["latin"],
   variable: "--font-serif",
+})
+const jetBrainsMono = JetBrains_Mono({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-mono",
 })
 
 const RailwayBlog = ({ Component, pageProps }: AppProps) => {
@@ -32,7 +40,9 @@ const RailwayBlog = ({ Component, pageProps }: AppProps) => {
         `}</style>
       </Head>
 
-      <div className={ibmPlexSerif.variable}>
+      <div
+        className={`${inter.variable} ${ibmPlexSerif.variable} ${jetBrainsMono.variable} font-sans`}
+      >
         <Component {...pageProps} />
       </div>
     </ThemeProvider>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,7 @@ const customColors = {
 }
 
 const fontStack = [
+  "var(--font-sans)",
   "Inter",
   "-apple-system",
   "BlinkMacSystemFont",
@@ -39,6 +40,8 @@ const fontStack = [
 ].join(",")
 
 const monoStack = [
+  "var(--font-mono)",
+  "JetBrains Mono",
   "ui-monospace",
   "SFMono-Regular",
   "SF Mono",
@@ -85,22 +88,28 @@ module.exports = {
           "radial-gradient(80.92% 283.41% at 34.4% -121.22%, #269ACC 0%, #461B9F 46.86%, #830757 100%)",
       },
       fontSize: {
+        // Editorial display heading (IBM Plex Serif Semibold)
+        "display-h1": [
+          "64px",
+          { lineHeight: "68px", letterSpacing: "-1.28px" },
+        ],
+
         // Headings
         huge: ["clamp(48px, 6vw, 64px)", "1.25"],
         jumbo: ["clamp(40px, 5vw, 48px)", "1.25"],
         large: ["clamp(32px, 4vw, 40px)", "1.25"],
-        h1: ["clamp(28px, 2.5vw, 32px)", "1.375"],
-        h2: ["clamp(24px, 3vw, 28px)", "1.375"],
-        h3: ["clamp(22px, 2.5vw, 24px)", "1.375"],
-        h4: ["20px", "1.375"],
-        h5: ["18px", "1.5"],
-        h6: ["16px", "1.5"],
+        h1: ["32px", "40px"],
+        h2: ["28px", "38px"],
+        h3: ["24px", "33px"],
+        h4: ["20px", "28px"],
+        h5: ["18px", "26px"],
+        h6: ["16px", "24px"],
 
         // Paragraphs
         xl: ["20px", "1.5"],
-        lg: ["18px", "1.5"],
+        lg: ["18px", "26px"],
         base: ["16px", "1.5"],
-        sm: ["14px", "21px"],
+        sm: ["14px", "20px"],
         xs: ["12px", "18px"],
       },
       typography: (theme) => ({

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -285,3 +285,25 @@ describe("MarkdownContent ordered lists", () => {
     expect(lists[1].getAttribute("start")).toBe("3")
   })
 })
+
+describe("MarkdownContent typography", () => {
+  it("uses the brand heading scale and weights", () => {
+    render(
+      <MarkdownContent
+        content={
+          "# Primary heading\n\n## Secondary heading\n\n### Tertiary heading"
+        }
+      />
+    )
+
+    expect(
+      screen.getByRole("heading", { name: "Primary heading" }).className
+    ).toEqual(expect.stringContaining("text-h1 font-semibold"))
+    expect(
+      screen.getByRole("heading", { name: "Secondary heading" }).className
+    ).toEqual(expect.stringContaining("text-h2 font-semibold"))
+    expect(
+      screen.getByRole("heading", { name: "Tertiary heading" }).className
+    ).toEqual(expect.stringContaining("text-h3 font-semibold"))
+  })
+})


### PR DESCRIPTION
## What

Aligns blog post typography with the Tracks brand system.

## Changes

- Expose Inter, IBM Plex Serif, and JetBrains Mono through `next/font` variables and the Tailwind font stacks.
- Match the brand heading and paragraph sizes, weights, line heights, and responsive post-title treatment.
- Apply the 40px title-to-content spacing from the type-pairing guidance and add regression coverage for Markdown headings.

## Verification

- `./node_modules/.bin/tsc --pretty --noEmit`
- `./node_modules/.bin/eslint components/MarkdownContent.tsx layouts/PostPage.tsx pages/_app.tsx test/components/MarkdownContent.test.tsx --ext ts --ext tsx`
- `./node_modules/.bin/tailwindcss -i styles/globals.css -o /private/tmp/blog-pr-tailwind.css --minify`
- Manually verified the rendered article at 1280×720 and 390×844: body copy resolves to Inter 18px/26px on desktop and 16px/24px on mobile.
- `./node_modules/.bin/jest test/components/MarkdownContent.test.tsx --runInBand` is blocked locally because the pnpm dependency layout causes Jest 27 to skip transforming the ESM-only `react-markdown` package.
