### PR TITLE
Align blog typography

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,8 +71,8 @@
             "message": "Body type tokens already provide the required line-height; remove the paragraph leading override."
           },
           {
-            "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\btext-gray-(?:300|400|500)\\b|\\bdark:text-gray-/]",
-            "message": "Use an AA-safe body tone such as text-gray-600 without a redundant dark override."
+            "selector": "JSXOpeningElement JSXAttribute[name.name='className'] Literal[value=/\\btext-gray-(?:300|400|500)\\b|\\bdark:text-gray-/]",
+            "message": "Use the AA-safe text-gray-600 tone without a redundant dark override."
           }
         ]
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,6 +73,10 @@
           {
             "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\btext-gray-(?:300|400|500)\\b|\\bdark:text-gray-/]",
             "message": "Use an AA-safe body tone such as text-gray-600 without a redundant dark override."
+          },
+          {
+            "selector": "Literal[value=/\\bfont-bold\\b/]",
+            "message": "Use font-semibold; bold weights are not part of the blog type system."
           }
         ]
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,8 +71,8 @@
             "message": "Body type tokens already provide the required line-height; remove the paragraph leading override."
           },
           {
-            "selector": "JSXOpeningElement JSXAttribute[name.name='className'] Literal[value=/\\btext-gray-(?:300|400|500)\\b|\\bdark:text-gray-/]",
-            "message": "Use the AA-safe text-gray-600 tone without a redundant dark override."
+            "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\btext-gray-(?:300|400|500)\\b|\\bdark:text-gray-/]",
+            "message": "Use an AA-safe body tone such as text-gray-600 without a redundant dark override."
           }
         ]
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,5 +51,31 @@
         "ignore": ["jsx", "global"]
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["components/**/*.tsx", "layouts/**/*.tsx", "pages/**/*.tsx"],
+      "rules": {
+        "no-restricted-syntax": [
+          "warn",
+          {
+            "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\btext-\\[[^\\]]+px\\]/]",
+            "message": "Use a body type token (text-xl/lg/base/sm/xs) instead of an arbitrary paragraph size."
+          },
+          {
+            "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\btext-(?:md|s|h[1-6]|[234]xl)\\b/]",
+            "message": "Paragraphs must use the body scale, not invalid or display-size classes."
+          },
+          {
+            "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\bleading-/]",
+            "message": "Body type tokens already provide the required line-height; remove the paragraph leading override."
+          },
+          {
+            "selector": "JSXOpeningElement[name.name='p'] JSXAttribute[name.name='className'] Literal[value=/\\btext-gray-(?:300|400|500)\\b|\\bdark:text-gray-/]",
+            "message": "Use an AA-safe body tone such as text-gray-600 without a redundant dark override."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/components/BottomCTA.tsx
+++ b/components/BottomCTA.tsx
@@ -15,7 +15,7 @@ export const BottomCTA: React.FC = () => {
       </p>
       <div className="mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row">
         <Link
-          href="https://dev.new"
+          href="https://railway.com"
           className="post-bottom-cta-primary inline-flex min-h-[48px] items-center justify-center rounded-[8px] px-6 py-3 text-base font-medium no-underline transition-colors duration-100"
         >
           Deploy a new project

--- a/components/BottomCTA.tsx
+++ b/components/BottomCTA.tsx
@@ -9,7 +9,7 @@ export const BottomCTA: React.FC = () => {
         "bg-bottomCta my-16 p-16 text-white rounded-xl flex flex-col items-center justify-center"
       )}
     >
-      <h3 className={cn("text-[40px] mb-4 font-bold")}>
+      <h3 className={cn("text-h3 mb-4")}>
         Your train has arrived!
       </h3>
       <p

--- a/components/BottomCTA.tsx
+++ b/components/BottomCTA.tsx
@@ -1,33 +1,32 @@
 import React from "react"
-import { cn } from "../utils"
 import Link from "./Link"
 
 export const BottomCTA: React.FC = () => {
   return (
-    <div
-      className={cn(
-        "bg-bottomCta my-16 p-16 text-white rounded-xl flex flex-col items-center justify-center"
-      )}
+    <section
+      className="post-bottom-cta my-16 border rounded-[16px] px-6 py-16 sm:px-12 sm:py-24 flex flex-col items-center justify-center text-center"
+      aria-labelledby="post-bottom-cta-title"
     >
-      <h3 className={cn("text-h3 mb-4")}>
-        Your train has arrived!
+      <h3 id="post-bottom-cta-title" className="text-h2 font-serif font-medium">
+        Ready to get started?
       </h3>
-      <p
-        className={cn(
-          "text-xl font-medium text-center max-w-xl text-opacity-90"
-        )}
-      >
-        Join millions of developers deploying millions of applications
-        effortlessly on Railway.
+      <p className="mt-4 text-base sm:text-lg text-gray-600">
+        Join millions of developers deploying applications on Railway
       </p>
-      <Link
-        href="https://dev.new"
-        className={cn(
-          "no-underline bg-white text-pink-500 py-3 px-5 rounded-lg mt-8 font-semibold text-xl"
-        )}
-      >
-        Start a New Project
-      </Link>
-    </div>
+      <div className="mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row">
+        <Link
+          href="https://dev.new"
+          className="post-bottom-cta-primary inline-flex min-h-[48px] items-center justify-center rounded-[8px] px-6 py-3 text-base font-medium no-underline transition-colors duration-100"
+        >
+          Deploy a new project
+        </Link>
+        <Link
+          href="https://railway.com/enterprise"
+          className="post-bottom-cta-secondary inline-flex min-h-[48px] items-center justify-center rounded-[8px] border px-6 py-3 text-base font-medium no-underline transition-colors duration-100"
+        >
+          Book a demo
+        </Link>
+      </div>
+    </section>
   )
 }

--- a/components/BottomCTA.tsx
+++ b/components/BottomCTA.tsx
@@ -12,7 +12,11 @@ export const BottomCTA: React.FC = () => {
       <h3 className={cn("text-[40px] mb-4 font-bold")}>
         Your train has arrived!
       </h3>
-      <p className={cn("text-xl text-center max-w-xl text-opacity-90")}>
+      <p
+        className={cn(
+          "text-xl font-medium text-center max-w-xl text-opacity-90"
+        )}
+      >
         Join millions of developers deploying millions of applications
         effortlessly on Railway.
       </p>

--- a/components/Categories.tsx
+++ b/components/Categories.tsx
@@ -40,7 +40,7 @@ const CategoryItem: React.FC<{
     <li className={className}>
       <Link
         className={`text-base font-medium ${
-          isActive ? "text-foreground" : "text-gray-500"
+          isActive ? "text-foreground" : "text-gray-600"
         } hover:text-foreground`}
         href={slug}
       >

--- a/components/ContinueReading.tsx
+++ b/components/ContinueReading.tsx
@@ -15,7 +15,7 @@ export const ContinueReading: React.FC<{
   return (
     <div>
       <header className={cn("flex items-center justify-between mb-8")}>
-        <h3 className="text-gray-500 font-semibold text-lg">
+        <h3 className="text-gray-600 font-semibold text-lg">
           Continue Reading...
         </h3>
         <Link
@@ -59,7 +59,7 @@ const RelatedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
           {post.title}
         </header>
 
-        <p className="text-base text-gray-800 line-clamp-2">
+        <p className="text-base text-gray-600 line-clamp-2">
           {post.description}
         </p>
       </div>

--- a/components/ContinueReading.tsx
+++ b/components/ContinueReading.tsx
@@ -15,9 +15,7 @@ export const ContinueReading: React.FC<{
   return (
     <div>
       <header className={cn("flex items-center justify-between mb-8")}>
-        <h3 className="text-gray-500 text-h3">
-          Continue Reading...
-        </h3>
+        <h3 className="text-gray-500 text-h3">Continue Reading...</h3>
         <Link
           className={cn("text-pink-500", "hover:underline")}
           href={getCategoryPath(category)}
@@ -74,7 +72,7 @@ const RelatedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
                     key={author.id}
                     src={author.avatarUrl}
                     alt={`Avatar of ${author.name}`}
-                    className="w-6 h-6 rounded-full overflow-hidden border-2 border-white"
+                    className="w-6 h-6 rounded-full overflow-hidden border-2 border-background"
                     style={{ marginLeft: index > 0 ? "-8px" : 0 }}
                     loading="lazy"
                     decoding="async"
@@ -90,9 +88,7 @@ const RelatedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
             <Divider />
           </>
         )}
-        <span className="text-sm text-gray-600">
-          {formattedDate}
-        </span>
+        <span className="text-sm text-gray-600">{formattedDate}</span>
       </div>
     </Link>
   )

--- a/components/ContinueReading.tsx
+++ b/components/ContinueReading.tsx
@@ -84,13 +84,13 @@ const RelatedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
                 ))}
               </div>
             )}
-            <span className="font-medium text-sm text-gray-500">
+            <span className="text-sm text-gray-600">
               {post.authors.map((author) => author.name).join(" & ")}
             </span>
             <Divider />
           </>
         )}
-        <span className="font-medium text-sm text-gray-500">
+        <span className="text-sm text-gray-600">
           {formattedDate}
         </span>
       </div>

--- a/components/ContinueReading.tsx
+++ b/components/ContinueReading.tsx
@@ -15,7 +15,7 @@ export const ContinueReading: React.FC<{
   return (
     <div>
       <header className={cn("flex items-center justify-between mb-8")}>
-        <h3 className="text-gray-500 font-semibold text-lg">
+        <h3 className="text-gray-500 text-h3">
           Continue Reading...
         </h3>
         <Link

--- a/components/ContinueReading.tsx
+++ b/components/ContinueReading.tsx
@@ -15,7 +15,7 @@ export const ContinueReading: React.FC<{
   return (
     <div>
       <header className={cn("flex items-center justify-between mb-8")}>
-        <h3 className="text-gray-600 font-semibold text-lg">
+        <h3 className="text-gray-500 font-semibold text-lg">
           Continue Reading...
         </h3>
         <Link
@@ -59,7 +59,7 @@ const RelatedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
           {post.title}
         </header>
 
-        <p className="text-base text-gray-600 line-clamp-2">
+        <p className="text-base text-gray-800 line-clamp-2">
           {post.description}
         </p>
       </div>

--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -4,12 +4,11 @@ import { BlogPost } from "@lib/types"
 import React, { useMemo } from "react"
 import { formatPostDate } from "../utils"
 import { Divider } from "./Divider"
-import { PostCategory, PostCategoryVariant } from "./PostCategory"
+import { PostCategory } from "./PostCategory"
 
 export const FeaturedPostItem: React.FC<{
   post: BlogPost
-  categoryVariant?: PostCategoryVariant
-}> = ({ post, categoryVariant }) => {
+}> = ({ post }) => {
   const formattedDate = useMemo(
     () => formatPostDate(post.publishedAt),
     [post.publishedAt]
@@ -46,7 +45,6 @@ export const FeaturedPostItem: React.FC<{
           <PostCategory
             category={post.category.title}
             isCommunity={post.externalAuthor}
-            variant={categoryVariant}
           />
         )}
 

--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -50,7 +50,7 @@ export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
           {post.title}
         </h3>
 
-        <p className="text-lg text-gray-800 line-clamp-2">
+        <p className="text-lg text-gray-600 line-clamp-2">
           {post.description}
         </p>
 
@@ -74,14 +74,14 @@ export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
                   ))}
                 </div>
               )}
-              <span className="font-medium text-sm text-gray-500">
+              <span className="text-sm text-gray-600">
                 {post.authors.map((author) => author.name).join(" & ")}
               </span>
               <Divider />
             </>
           )}
 
-          <span className="font-medium text-sm text-gray-500">
+          <span className="text-sm text-gray-600">
             {formattedDate}
           </span>
         </div>

--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -4,9 +4,12 @@ import { BlogPost } from "@lib/types"
 import React, { useMemo } from "react"
 import { formatPostDate } from "../utils"
 import { Divider } from "./Divider"
-import { PostCategory } from "./PostCategory"
+import { PostCategory, PostCategoryVariant } from "./PostCategory"
 
-export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
+export const FeaturedPostItem: React.FC<{
+  post: BlogPost
+  categoryVariant?: PostCategoryVariant
+}> = ({ post, categoryVariant }) => {
   const formattedDate = useMemo(
     () => formatPostDate(post.publishedAt),
     [post.publishedAt]
@@ -43,6 +46,7 @@ export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
           <PostCategory
             category={post.category.title}
             isCommunity={post.externalAuthor}
+            variant={categoryVariant}
           />
         )}
 

--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -46,7 +46,7 @@ export const FeaturedPostItem: React.FC<{ post: BlogPost }> = ({ post }) => {
           />
         )}
 
-        <h3 className="font-medium font-serif text-2xl my-4 group-hover:opacity-60 tracking-tight">
+        <h3 className="font-serif text-h3 my-4 group-hover:opacity-60">
           {post.title}
         </h3>
 

--- a/components/FeaturedPostItem.tsx
+++ b/components/FeaturedPostItem.tsx
@@ -52,9 +52,7 @@ export const FeaturedPostItem: React.FC<{
           {post.title}
         </h3>
 
-        <p className="text-lg text-gray-600 line-clamp-2">
-          {post.description}
-        </p>
+        <p className="text-lg text-gray-600 line-clamp-2">{post.description}</p>
 
         <div className="flex items-center gap-3 mt-6">
           {post.authors.length > 0 && (
@@ -66,7 +64,7 @@ export const FeaturedPostItem: React.FC<{
                       key={author.id}
                       src={author.avatarUrl}
                       alt={`Avatar of ${author.name}`}
-                      className="w-6 h-6 rounded-full overflow-hidden border-2 border-white"
+                      className="w-6 h-6 rounded-full overflow-hidden border-2 border-background"
                       style={{ marginLeft: index > 0 ? "-8px" : 0 }}
                       loading="lazy"
                       decoding="async"
@@ -83,9 +81,7 @@ export const FeaturedPostItem: React.FC<{
             </>
           )}
 
-          <span className="text-sm text-gray-600">
-            {formattedDate}
-          </span>
+          <span className="text-sm text-gray-600">{formattedDate}</span>
         </div>
       </div>
     </Link>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -17,10 +17,10 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="col-span-1 sm:col-span-2">
-          <p className="text-xs font-bold uppercase text-gray-500 mb-4">
+          <p className="text-xs font-medium uppercase text-gray-600 mb-4">
             Product
           </p>
-          <ul className="text-gray-500 space-y-4">
+          <ul className="text-gray-600 space-y-4">
             <FooterListLink href={railwayUrl("changelog")}>
               Changelog
             </FooterListLink>
@@ -40,10 +40,10 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="col-span-1 sm:col-span-2">
-          <p className="text-xs font-bold uppercase text-gray-500 mb-4">
+          <p className="text-xs font-medium uppercase text-gray-600 mb-4">
             Company
           </p>
-          <ul className="text-gray-500 space-y-4">
+          <ul className="text-gray-600 space-y-4">
             <FooterListLink href={railwayUrl("about")}>About</FooterListLink>
             <FooterListLink href={railwayUrl("careers")}>
               Careers
@@ -56,10 +56,10 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="col-span-1 sm:col-span-2">
-          <p className="text-xs font-bold uppercase text-gray-500 mb-4">
+          <p className="text-xs font-medium uppercase text-gray-600 mb-4">
             Contact
           </p>
-          <ul className="text-gray-500 space-y-4">
+          <ul className="text-gray-600 space-y-4">
             <FooterListLink href={"https://discord.gg/railway"}>
               Discord
             </FooterListLink>
@@ -76,10 +76,10 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="col-span-1 sm:col-span-2">
-          <p className="text-xs font-bold uppercase text-gray-500 mb-4">
+          <p className="text-xs font-medium uppercase text-gray-600 mb-4">
             Legal
           </p>
-          <ul className="text-gray-500 space-y-4">
+          <ul className="text-gray-600 space-y-4">
             <FooterListLink href={railwayUrl("legal/acceptable-use")}>
               Acceptable Use
             </FooterListLink>
@@ -110,7 +110,7 @@ const FooterListLink: React.FC<{
 )
 
 const Copyright: React.FC = () => (
-  <div className="text-xs text-gray-500 w-full">
+  <div className="text-xs font-medium text-gray-600 w-full">
     Copyright © {new Date().getFullYear()} Railway Corp. <br />
     All rights reserved.
   </div>

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -305,7 +305,7 @@ const MarkdownSegmentRenderer: React.FC<{
             })}
             sizes="(max-width: 768px) 100vw, 736px"
             alt={alt ?? ""}
-            className="w-full rounded-lg"
+            className="w-full rounded-[4px]"
             loading="lazy"
             decoding="async"
           />

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -322,9 +322,11 @@ const MarkdownSegmentRenderer: React.FC<{
         {children}
       </blockquote>
     ),
-    ul: ({ children }) => <ul className="list-disc pl-6 mb-4">{children}</ul>,
+    ul: ({ children }) => (
+      <ul className="list-disc pl-6 mb-4 text-gray-800">{children}</ul>
+    ),
     ol: ({ children, start }) => (
-      <ol start={start} className="list-decimal pl-6 mb-4">
+      <ol start={start} className="list-decimal pl-6 mb-4 text-gray-800">
         {children}
       </ol>
     ),

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -13,7 +13,7 @@ import ReactMarkdown from "react-markdown"
 import { TwitterTweetEmbed } from "react-twitter-embed"
 import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
-import { extractTweetId, extractYoutubeId } from "utils"
+import { cn, extractTweetId, extractYoutubeId } from "utils"
 
 type RenderMode = "page" | "rss"
 
@@ -194,7 +194,7 @@ const MarkdownSegmentRenderer: React.FC<{
         return <>{children}</>
       }
 
-      return <p className="mb-4 text-gray-800">{children}</p>
+      return <p className="mb-4">{children}</p>
     },
     a: ({ href, children, node }) => {
       const label = getNodeText(children)
@@ -420,7 +420,7 @@ export const MarkdownContent: React.FC<Props> = ({
   const segments = segmentMarkdown(content)
 
   return (
-    <div className={className}>
+    <div className={cn("text-gray-600", className)}>
       {segments.map((segment, index) =>
         segment.type === "callout" ? (
           <Callout

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -13,7 +13,7 @@ import ReactMarkdown from "react-markdown"
 import { TwitterTweetEmbed } from "react-twitter-embed"
 import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
-import { cn, extractTweetId, extractYoutubeId } from "utils"
+import { extractTweetId, extractYoutubeId } from "utils"
 
 type RenderMode = "page" | "rss"
 
@@ -194,7 +194,7 @@ const MarkdownSegmentRenderer: React.FC<{
         return <>{children}</>
       }
 
-      return <p className="mb-4">{children}</p>
+      return <p className="mb-4 text-gray-800">{children}</p>
     },
     a: ({ href, children, node }) => {
       const label = getNodeText(children)
@@ -420,7 +420,7 @@ export const MarkdownContent: React.FC<Props> = ({
   const segments = segmentMarkdown(content)
 
   return (
-    <div className={cn("text-gray-600", className)}>
+    <div className={className}>
       {segments.map((segment, index) =>
         segment.type === "callout" ? (
           <Callout

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -175,18 +175,18 @@ const MarkdownSegmentRenderer: React.FC<{
 }> = ({ content, mode, slugger }) => {
   const components = {
     // Markdown `#` headings render as h2: the post title is the page's only
-    // h1. Styling keeps the original h1 scale so posts look unchanged.
+    // h1. Both Markdown h1 and h2 use the article's H2 type token.
     h1: ({ children }) =>
       renderHeading(
         "h2",
-        "text-4xl font-bold leading-snug mt-16 mb-8",
+        "text-h2 mt-16 mb-8",
         slugger,
         children
       ),
     h2: ({ children }) =>
-      renderHeading("h2", "text-h2 font-bold mt-10 mb-5", slugger, children),
+      renderHeading("h2", "text-h2 mt-10 mb-6", slugger, children),
     h3: ({ children }) =>
-      renderHeading("h3", "text-xl font-bold mt-6 mb-4", slugger, children),
+      renderHeading("h3", "text-h3 mt-6 mb-4", slugger, children),
     p: ({ children, node }) => {
       const childArray = React.Children.toArray(children)
 

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -305,7 +305,7 @@ const MarkdownSegmentRenderer: React.FC<{
             })}
             sizes="(max-width: 768px) 100vw, 736px"
             alt={alt ?? ""}
-            className="w-full rounded-[4px]"
+            className="w-full rounded-[8px]"
             loading="lazy"
             decoding="async"
           />

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -323,14 +323,18 @@ const MarkdownSegmentRenderer: React.FC<{
       </blockquote>
     ),
     ul: ({ children }) => (
-      <ul className="list-disc pl-6 mb-4 text-gray-800">{children}</ul>
+      <ul className="list-disc pl-6 mb-4 space-y-4 text-gray-800">
+        {children}
+      </ul>
     ),
     ol: ({ children, start }) => (
-      <ol start={start} className="list-decimal pl-6 mb-4 text-gray-800">
+      <ol
+        start={start}
+        className="list-decimal pl-6 mb-4 space-y-4 text-gray-800"
+      >
         {children}
       </ol>
     ),
-    li: ({ children }) => <li className="mb-2">{children}</li>,
     table: ({ children }) => (
       <div className="my-8 overflow-x-auto">
         <table className="w-full border-collapse text-left text-sm">

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -380,11 +380,7 @@ const MarkdownSegmentRenderer: React.FC<{
         )
       }
 
-      return (
-        <code className="text-pink-600 whitespace-normal break-words">
-          {children}
-        </code>
-      )
+      return <code className="inline-code">{children}</code>
     },
     hr: () => <hr className="my-8" />,
   }

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -194,7 +194,7 @@ const MarkdownSegmentRenderer: React.FC<{
         return <>{children}</>
       }
 
-      return <p className="mb-4 leading-8 text-gray-800">{children}</p>
+      return <p className="mb-4 text-gray-800">{children}</p>
     },
     a: ({ href, children, node }) => {
       const label = getNodeText(children)
@@ -328,7 +328,7 @@ const MarkdownSegmentRenderer: React.FC<{
         {children}
       </ol>
     ),
-    li: ({ children }) => <li className="mb-2 leading-8">{children}</li>,
+    li: ({ children }) => <li className="mb-2">{children}</li>,
     table: ({ children }) => (
       <div className="my-8 overflow-x-auto">
         <table className="w-full border-collapse text-left text-sm">

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -285,7 +285,7 @@ const MarkdownSegmentRenderer: React.FC<{
       }
 
       return (
-        <Link href={href ?? "#"} className="underline hover:text-pink-600">
+        <Link href={href ?? "#"} className="markdown-inline-link">
           {children}
         </Link>
       )

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -24,7 +24,7 @@ const Nav: React.FC = () => {
       >
         <Link href="/" className="flex items-center space-x-4">
           <Logo />
-          <span className="text-xl font-bold">Blog</span>
+          <span className="text-xl font-semibold">Blog</span>
         </Link>
 
         <div className="text-gray-600 flex items-center space-x-6">

--- a/components/PostCategory.tsx
+++ b/components/PostCategory.tsx
@@ -1,6 +1,22 @@
 import React from "react"
 import { cn } from "../utils"
 
+type PostCategoryTone = "plum" | "gold" | "teal" | "blue" | "wine"
+
+const categoryToTone: Record<string, PostCategoryTone> = {
+  Engineering: "plum",
+  "Scaling Railway": "plum",
+  News: "gold",
+  AI: "teal",
+  Community: "teal",
+  Guide: "blue",
+  Company: "wine",
+  "User Stories": "wine",
+}
+
+const getCategoryTone = (category: string): PostCategoryTone =>
+  categoryToTone[category] ?? "plum"
+
 export const PostCategory: React.FC<{
   category: string
   isCommunity: boolean
@@ -14,8 +30,20 @@ export const PostCategory: React.FC<{
 
   return (
     <div className="flex gap-2">
-      <div className={getPillClassName()}>{category}</div>
-      {isCommunity && <div className={getPillClassName()}>Community</div>}
+      <div
+        className={getPillClassName()}
+        data-category-tone={getCategoryTone(category)}
+      >
+        {category}
+      </div>
+      {isCommunity && (
+        <div
+          className={getPillClassName()}
+          data-category-tone={getCategoryTone("Community")}
+        >
+          Community
+        </div>
+      )}
     </div>
   )
 }

--- a/components/PostCategory.tsx
+++ b/components/PostCategory.tsx
@@ -1,38 +1,21 @@
 import React from "react"
 import { cn } from "../utils"
 
-const categoryToStyle = {
-  News: "text-blue-500 bg-blue-50",
-  Guide: "text-green-500 bg-green-50",
-  Company: "text-pink-500 bg-pink-50",
-  Engineering: "text-pink-500 bg-pink-50",
-  Community: "text-green-500 bg-green-50",
-  "User Stories": "text-pink-500 bg-pink-50",
-  "Scaling Railway": "text-green-500 bg-green-50",
-}
-
 export const PostCategory: React.FC<{
   category: string
   isCommunity: boolean
   className?: string
 }> = ({ category, isCommunity, className }) => {
-  const getPillClassName = (pillCategory: string) =>
+  const getPillClassName = () =>
     cn(
-      categoryToStyle[pillCategory] ?? "text-gray-600 bg-gray-50",
       "post-category-pill font-medium max-w-max text-xs px-2 py-[3px] rounded-[4px] tracking-[0.06em] uppercase",
       className
     )
 
   return (
     <div className="flex gap-2">
-      <div className={getPillClassName(category)}>
-        {category}
-      </div>
-      {isCommunity && (
-        <div className={getPillClassName("Community")}>
-          Community
-        </div>
-      )}
+      <div className={getPillClassName()}>{category}</div>
+      {isCommunity && <div className={getPillClassName()}>Community</div>}
     </div>
   )
 }

--- a/components/PostCategory.tsx
+++ b/components/PostCategory.tsx
@@ -19,16 +19,18 @@ export const PostCategory: React.FC<{
     <div className="flex gap-2">
       <div
         className={`${
-          categoryToStyle[category] ?? "text-gray-500 bg-gray-50"
-        } font-bold px-1.5 py-1 rounded max-w-max text-xs uppercase ${className}`}
-        >
+          categoryToStyle[category] ?? "text-gray-600 bg-gray-50"
+        } font-medium px-1.5 py-1 rounded max-w-max text-xs uppercase ${className}`}
+      >
         {category}
       </div>
-      {isCommunity && 
-      <div 
-        className={`${categoryToStyle["Community"]} font-bold px-1.5 py-1 
-        rounded max-w-max text-xs uppercase`}>Community
-      </div>}
+      {isCommunity && (
+        <div
+          className={`${categoryToStyle["Community"]} font-medium px-1.5 py-1 rounded max-w-max text-xs uppercase`}
+        >
+          Community
+        </div>
+      )}
     </div>
   )
 }

--- a/components/PostCategory.tsx
+++ b/components/PostCategory.tsx
@@ -11,21 +11,15 @@ const categoryToStyle = {
   "Scaling Railway": "text-green-500 bg-green-50",
 }
 
-export type PostCategoryVariant = "default" | "homepage"
-
 export const PostCategory: React.FC<{
   category: string
   isCommunity: boolean
   className?: string
-  variant?: PostCategoryVariant
-}> = ({ category, isCommunity, className, variant = "default" }) => {
+}> = ({ category, isCommunity, className }) => {
   const getPillClassName = (pillCategory: string) =>
     cn(
       categoryToStyle[pillCategory] ?? "text-gray-600 bg-gray-50",
-      "font-medium max-w-max text-xs",
-      variant === "homepage"
-        ? "homepage-category-pill px-2 py-[3px] rounded-[4px] tracking-[0.06em] uppercase"
-        : "px-1.5 py-1 rounded uppercase",
+      "post-category-pill font-medium max-w-max text-xs px-2 py-[3px] rounded-[4px] tracking-[0.06em] uppercase",
       className
     )
 

--- a/components/PostCategory.tsx
+++ b/components/PostCategory.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { cn } from "../utils"
 
 const categoryToStyle = {
   News: "text-blue-500 bg-blue-50",
@@ -10,24 +11,31 @@ const categoryToStyle = {
   "Scaling Railway": "text-green-500 bg-green-50",
 }
 
+export type PostCategoryVariant = "default" | "homepage"
+
 export const PostCategory: React.FC<{
   category: string
   isCommunity: boolean
   className?: string
-}> = ({ category, isCommunity, className }) => {
+  variant?: PostCategoryVariant
+}> = ({ category, isCommunity, className, variant = "default" }) => {
+  const getPillClassName = (pillCategory: string) =>
+    cn(
+      categoryToStyle[pillCategory] ?? "text-gray-600 bg-gray-50",
+      "font-medium max-w-max text-xs",
+      variant === "homepage"
+        ? "homepage-category-pill px-2 py-[3px] rounded-[6px] tracking-[0.06em] uppercase"
+        : "px-1.5 py-1 rounded uppercase",
+      className
+    )
+
   return (
     <div className="flex gap-2">
-      <div
-        className={`${
-          categoryToStyle[category] ?? "text-gray-600 bg-gray-50"
-        } font-medium px-1.5 py-1 rounded max-w-max text-xs uppercase ${className}`}
-      >
+      <div className={getPillClassName(category)}>
         {category}
       </div>
       {isCommunity && (
-        <div
-          className={`${categoryToStyle["Community"]} font-medium px-1.5 py-1 rounded max-w-max text-xs uppercase`}
-        >
+        <div className={getPillClassName("Community")}>
           Community
         </div>
       )}

--- a/components/PostCategory.tsx
+++ b/components/PostCategory.tsx
@@ -24,7 +24,7 @@ export const PostCategory: React.FC<{
       categoryToStyle[pillCategory] ?? "text-gray-600 bg-gray-50",
       "font-medium max-w-max text-xs",
       variant === "homepage"
-        ? "homepage-category-pill px-2 py-[3px] rounded-[6px] tracking-[0.06em] uppercase"
+        ? "homepage-category-pill px-2 py-[3px] rounded-[4px] tracking-[0.06em] uppercase"
         : "px-1.5 py-1 rounded uppercase",
       className
     )

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -30,7 +30,7 @@ const PostItem: React.FC<Props> = ({ post }) => {
           {post.title}
         </h4>
 
-        <p className="text-base text-gray-800 line-clamp-2">
+        <p className="text-base text-gray-600 line-clamp-2">
           {post.description}
         </p>
       </div>
@@ -55,13 +55,13 @@ const PostItem: React.FC<Props> = ({ post }) => {
                 ))}
               </div>
             )}
-            <span className="font-medium text-sm text-gray-500">
+            <span className="text-sm text-gray-600">
               {post.authors.map((author) => author.name).join(" & ")}
             </span>
             <Divider />
           </>
         )}
-        <span className="font-medium text-sm text-gray-500">
+        <span className="text-sm text-gray-600">
           {formattedDate}
         </span>
       </div>

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -3,13 +3,14 @@ import { BlogPost } from "@lib/types"
 import React, { useMemo } from "react"
 import { formatPostDate } from "../utils"
 import { Divider } from "./Divider"
-import { PostCategory } from "./PostCategory"
+import { PostCategory, PostCategoryVariant } from "./PostCategory"
 
 export interface Props {
   post: BlogPost
+  categoryVariant?: PostCategoryVariant
 }
 
-const PostItem: React.FC<Props> = ({ post }) => {
+const PostItem: React.FC<Props> = ({ post, categoryVariant }) => {
   const formattedDate = useMemo(
     () => formatPostDate(post.publishedAt),
     [post.publishedAt]
@@ -22,6 +23,7 @@ const PostItem: React.FC<Props> = ({ post }) => {
         <PostCategory
           category={post.category.title}
           isCommunity={post.externalAuthor}
+          variant={categoryVariant}
         />
       )}
 

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -17,7 +17,10 @@ const PostItem: React.FC<Props> = ({ post }) => {
   const authorsWithAvatars = post.authors.filter((author) => author.avatarUrl)
 
   return (
-    <Link href={`/p/${post.slug}`} className="flex flex-col border-b border-gray-100 group">
+    <Link
+      href={`/p/${post.slug}`}
+      className="flex flex-col border-b border-gray-100 group"
+    >
       {post.category != null && (
         <PostCategory
           category={post.category.title}
@@ -45,7 +48,7 @@ const PostItem: React.FC<Props> = ({ post }) => {
                     key={author.id}
                     src={author.avatarUrl}
                     alt={`Avatar of ${author.name}`}
-                    className="w-6 h-6 rounded-full overflow-hidden border-2 border-white"
+                    className="w-6 h-6 rounded-full overflow-hidden border-2 border-background"
                     style={{ marginLeft: index > 0 ? "-8px" : 0 }}
                     loading="lazy"
                     decoding="async"
@@ -61,9 +64,7 @@ const PostItem: React.FC<Props> = ({ post }) => {
             <Divider />
           </>
         )}
-        <span className="text-sm text-gray-600">
-          {formattedDate}
-        </span>
+        <span className="text-sm text-gray-600">{formattedDate}</span>
       </div>
     </Link>
   )

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -3,14 +3,13 @@ import { BlogPost } from "@lib/types"
 import React, { useMemo } from "react"
 import { formatPostDate } from "../utils"
 import { Divider } from "./Divider"
-import { PostCategory, PostCategoryVariant } from "./PostCategory"
+import { PostCategory } from "./PostCategory"
 
 export interface Props {
   post: BlogPost
-  categoryVariant?: PostCategoryVariant
 }
 
-const PostItem: React.FC<Props> = ({ post, categoryVariant }) => {
+const PostItem: React.FC<Props> = ({ post }) => {
   const formattedDate = useMemo(
     () => formatPostDate(post.publishedAt),
     [post.publishedAt]
@@ -23,7 +22,6 @@ const PostItem: React.FC<Props> = ({ post, categoryVariant }) => {
         <PostCategory
           category={post.category.title}
           isCommunity={post.externalAuthor}
-          variant={categoryVariant}
         />
       )}
 

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -50,7 +50,13 @@ export const PostList: React.FC<{
             (e.g. a new category whose posts are all featured). */}
         {(otherPosts.length > 0 || category != null) && (
           <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-3 mb-24 mt-24">
-            <ListHeading className="text-3xl font-bold mb-12">
+            <ListHeading
+              className={
+                category == null
+                  ? "text-h2 mb-12"
+                  : "text-3xl font-bold mb-12"
+              }
+            >
               {category == null ? "Everything" : getCategoryLabel(category)}
             </ListHeading>
 

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -1,6 +1,7 @@
 import { getCategoryLabel } from "@lib/cms"
 import React, { useState } from "react"
 import { BlogCategory, BlogPost } from "../lib/types"
+import { cn } from "../utils"
 import { Categories } from "./Categories"
 import { FeaturedPostItem } from "./FeaturedPostItem"
 import PostItem from "./PostItem"
@@ -53,7 +54,12 @@ export const PostList: React.FC<{
         {/* Category pages always render the heading — it is their only h1 —
             even when the category does not contain any posts. */}
         {(otherPosts.length > 0 || category != null) && (
-          <div className="max-w-6xl mx-auto mb-24 mt-24">
+          <div
+            className={cn(
+              "max-w-6xl mx-auto mb-24",
+              category == null ? "mt-16" : "mt-24"
+            )}
+          >
             <ListHeading
               className={
                 category == null

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -54,7 +54,7 @@ export const PostList: React.FC<{
               className={
                 category == null
                   ? "text-h2 mb-12"
-                  : "text-3xl font-bold mb-12"
+                  : "text-3xl font-semibold mb-12"
               }
             >
               {category == null ? "Everything" : getCategoryLabel(category)}

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -53,7 +53,7 @@ export const PostList: React.FC<{
             even when every post is featured and the card list is empty
             (e.g. a new category whose posts are all featured). */}
         {(otherPosts.length > 0 || category != null) && (
-          <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-3 mb-24 mt-24">
+          <div className="max-w-6xl mx-auto mb-24 mt-24">
             <ListHeading
               className={
                 category == null
@@ -65,7 +65,7 @@ export const PostList: React.FC<{
             </ListHeading>
 
             {otherPosts.length > 0 && (
-              <div className="col-span-1 lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8 [&>*:nth-last-child(2)]:border-transparent md:[&>*:nth-last-child(3)]:border-transparent">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-8 [&>*:nth-last-child(2)]:border-transparent md:[&>*:nth-last-child(3)]:border-transparent lg:[&>*:nth-last-child(4)]:border-transparent">
                 {otherPosts
                   .slice(0, showMore ? undefined : DEFAULT_POSTS_LENGTH)
                   .map((post) => (
@@ -82,7 +82,7 @@ export const PostList: React.FC<{
                   <div />
                 ) : (
                   <button
-                    className="md:col-span-2 w-full text-center text-pink-700 border border-pink-200 rounded-md px-4 py-2 hover:text-pink-800 hover:border-pink-500 transition-colors duration-100"
+                    className="md:col-span-2 lg:col-span-3 w-full text-center text-pink-700 border border-pink-200 rounded-md px-4 py-2 hover:text-pink-800 hover:border-pink-500 transition-colors duration-100"
                     onClick={() => setShowMore(true)}
                   >
                     Load more posts...

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -37,10 +37,7 @@ export const PostList: React.FC<{
           {featuredPosts.length > 0 && (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8 md:gap-y-12">
               {featuredPosts.map((post) => (
-                <FeaturedPostItem
-                  key={post.id}
-                  post={post}
-                />
+                <FeaturedPostItem key={post.id} post={post} />
               ))}
             </div>
           )}
@@ -74,17 +71,14 @@ export const PostList: React.FC<{
                 {otherPosts
                   .slice(0, showMore ? undefined : DEFAULT_POSTS_LENGTH)
                   .map((post) => (
-                    <PostItem
-                      key={post.id}
-                      post={post}
-                    />
+                    <PostItem key={post.id} post={post} />
                   ))}
 
                 {showMore || !hasMorePosts ? (
                   <div />
                 ) : (
                   <button
-                    className="md:col-span-2 lg:col-span-3 w-full text-center text-pink-700 border border-pink-200 rounded-md px-4 py-2 hover:text-pink-800 hover:border-pink-500 transition-colors duration-100"
+                    className="load-more-posts md:col-span-2 lg:col-span-3 justify-self-center text-center border rounded-[4px] px-4 py-2 transition-colors duration-100"
                     onClick={() => setShowMore(true)}
                   >
                     Load more posts...

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -7,6 +7,7 @@ import { FeaturedPostItem } from "./FeaturedPostItem"
 import PostItem from "./PostItem"
 
 const DEFAULT_POSTS_LENGTH = 8
+const POSTS_BATCH_SIZE = 6
 
 export const PostList: React.FC<{
   posts: BlogPost[]
@@ -21,8 +22,9 @@ export const PostList: React.FC<{
       ? posts.filter((post) => !post.featured && !post.externalAuthor)
       : posts
 
-  const [showMore, setShowMore] = useState(false)
-  const hasMorePosts = otherPosts.length > DEFAULT_POSTS_LENGTH
+  const [visiblePostsLength, setVisiblePostsLength] =
+    useState(DEFAULT_POSTS_LENGTH)
+  const hasMorePosts = otherPosts.length > visiblePostsLength
 
   // Category pages have no other h1; the homepage's h1 lives elsewhere.
   const ListHeading = category == null ? "h2" : "h1"
@@ -68,33 +70,38 @@ export const PostList: React.FC<{
 
             {otherPosts.length > 0 && (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-8 [&>*:nth-last-child(2)]:border-transparent md:[&>*:nth-last-child(3)]:border-transparent lg:[&>*:nth-last-child(4)]:border-transparent">
-                {otherPosts
-                  .slice(0, showMore ? undefined : DEFAULT_POSTS_LENGTH)
-                  .map((post) => (
-                    <PostItem key={post.id} post={post} />
-                  ))}
+                {otherPosts.slice(0, visiblePostsLength).map((post) => (
+                  <PostItem key={post.id} post={post} />
+                ))}
 
-                {showMore || !hasMorePosts ? (
-                  <div />
-                ) : (
+                {hasMorePosts ? (
                   <button
                     className="load-more-posts md:col-span-2 lg:col-span-3 justify-self-center text-center border rounded-[4px] px-4 py-2 transition-colors duration-100"
-                    onClick={() => setShowMore(true)}
+                    onClick={() =>
+                      setVisiblePostsLength((currentLength) =>
+                        Math.min(
+                          currentLength + POSTS_BATCH_SIZE,
+                          otherPosts.length
+                        )
+                      )
+                    }
                   >
                     Load more posts
                   </button>
+                ) : (
+                  <div />
                 )}
               </div>
             )}
 
             {/* Crawlable links for the posts hidden behind "Load more" so
                 every post is reachable in the server-rendered HTML. Plain
-                <a> (never visible or clickable); unmounts once the full
-                cards render. Kept outside the cards grid so its
+                <a> (never visible or clickable); shrinks as each batch of
+                cards renders. Kept outside the cards grid so its
                 nth-last-child border CSS keeps counting correctly. */}
-            {!showMore && hasMorePosts && (
+            {hasMorePosts && (
               <ul className="hidden">
-                {otherPosts.slice(DEFAULT_POSTS_LENGTH).map((post) => (
+                {otherPosts.slice(visiblePostsLength).map((post) => (
                   <li key={post.id}>
                     <a href={`/p/${post.slug}`}>{post.title}</a>
                   </li>

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -35,7 +35,11 @@ export const PostList: React.FC<{
           {featuredPosts.length > 0 && (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8 md:gap-y-12">
               {featuredPosts.map((post) => (
-                <FeaturedPostItem key={post.id} post={post} />
+                <FeaturedPostItem
+                  key={post.id}
+                  post={post}
+                  categoryVariant={category == null ? "homepage" : "default"}
+                />
               ))}
             </div>
           )}
@@ -65,7 +69,13 @@ export const PostList: React.FC<{
                 {otherPosts
                   .slice(0, showMore ? undefined : DEFAULT_POSTS_LENGTH)
                   .map((post) => (
-                    <PostItem key={post.id} post={post} />
+                    <PostItem
+                      key={post.id}
+                      post={post}
+                      categoryVariant={
+                        category == null ? "homepage" : "default"
+                      }
+                    />
                   ))}
 
                 {showMore || !hasMorePosts ? (

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -12,12 +12,13 @@ export const PostList: React.FC<{
   categories: BlogCategory[]
   category?: BlogCategory | string
 }> = ({ posts, categories, category }) => {
-  const featuredPosts = posts.filter((post) => post.featured)
+  const featuredPosts =
+    category == null ? posts.filter((post) => post.featured) : []
 
   const otherPosts =
     category == null
       ? posts.filter((post) => !post.featured && !post.externalAuthor)
-      : posts.filter((post) => !post.featured)
+      : posts
 
   const [showMore, setShowMore] = useState(false)
   const hasMorePosts = otherPosts.length > DEFAULT_POSTS_LENGTH
@@ -50,8 +51,7 @@ export const PostList: React.FC<{
         )}
 
         {/* Category pages always render the heading — it is their only h1 —
-            even when every post is featured and the card list is empty
-            (e.g. a new category whose posts are all featured). */}
+            even when the category does not contain any posts. */}
         {(otherPosts.length > 0 || category != null) && (
           <div className="max-w-6xl mx-auto mb-24 mt-24">
             <ListHeading

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -40,7 +40,6 @@ export const PostList: React.FC<{
                 <FeaturedPostItem
                   key={post.id}
                   post={post}
-                  categoryVariant={category == null ? "homepage" : "default"}
                 />
               ))}
             </div>
@@ -78,9 +77,6 @@ export const PostList: React.FC<{
                     <PostItem
                       key={post.id}
                       post={post}
-                      categoryVariant={
-                        category == null ? "homepage" : "default"
-                      }
                     />
                   ))}
 

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -81,7 +81,7 @@ export const PostList: React.FC<{
                     className="load-more-posts md:col-span-2 lg:col-span-3 justify-self-center text-center border rounded-[4px] px-4 py-2 transition-colors duration-100"
                     onClick={() => setShowMore(true)}
                   >
-                    Load more posts...
+                    Load more posts
                   </button>
                 )}
               </div>

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -102,7 +102,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
             </h1>
           </header>
 
-          <section className="max-w-[672px] mx-auto text-base sm:text-lg">
+          <section className="max-w-[704px] mx-auto text-base sm:text-lg">
             <HiddenTableOfContents items={tableOfContents} />
             <MarkdownContent content={post.content ?? ""} />
           </section>

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -67,7 +67,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
               : "pb-12"
           )}
         >
-          <div className="max-w-[736px] mx-auto flex items-center text-gray-500 space-x-3">
+          <div className="max-w-[736px] mx-auto flex items-center text-sm text-gray-600 space-x-3">
             {post.authors.length > 0 && (
               <>
                 <div className="flex items-center space-x-3">
@@ -100,7 +100,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
             <h1 className="text-6xl font-medium font-serif">{post.title}</h1>
           </header>
 
-          <section className="max-w-[736px] mx-auto text-base sm:text-lg leading-8">
+          <section className="max-w-[736px] mx-auto text-base sm:text-lg">
             <HiddenTableOfContents items={tableOfContents} />
             <MarkdownContent content={post.content ?? ""} />
           </section>

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -79,7 +79,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
                           key={author.id}
                           src={author.avatarUrl}
                           alt={`Avatar of ${author.name}`}
-                          className="w-6 h-6 rounded-full overflow-hidden border-2 border-white"
+                          className="w-6 h-6 rounded-full overflow-hidden border-2 border-background"
                           style={{ marginLeft: index > 0 ? "-8px" : 0 }}
                           loading="lazy"
                           decoding="async"

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -97,7 +97,9 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
           </div>
 
           <header className="mt-5 mb-16 max-w-[736px] mx-auto">
-            <h1 className="text-6xl font-medium font-serif">{post.title}</h1>
+            <h1 className="text-post-title font-medium font-serif">
+              {post.title}
+            </h1>
           </header>
 
           <section className="max-w-[736px] mx-auto text-base sm:text-lg">

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -67,7 +67,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
               : "pb-12"
           )}
         >
-          <div className="max-w-[736px] mx-auto flex items-center text-sm text-gray-600 space-x-3">
+          <div className="max-w-[704px] mx-auto flex items-center text-sm text-gray-600 space-x-3">
             {post.authors.length > 0 && (
               <>
                 <div className="flex items-center space-x-3">
@@ -96,7 +96,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
             <time dateTime={post.publishedAt}>{formattedDate}</time>
           </div>
 
-          <header className="mt-5 mb-16 max-w-[736px] mx-auto">
+          <header className="mt-5 mb-16 max-w-[704px] mx-auto">
             <h1 className="text-post-title font-medium font-serif">
               {post.title}
             </h1>

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -102,7 +102,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
             </h1>
           </header>
 
-          <section className="max-w-[736px] mx-auto text-base sm:text-lg">
+          <section className="max-w-[672px] mx-auto text-base sm:text-lg">
             <HiddenTableOfContents items={tableOfContents} />
             <MarkdownContent content={post.content ?? ""} />
           </section>

--- a/lib/rss/index.ts
+++ b/lib/rss/index.ts
@@ -30,7 +30,7 @@ const renderPostContent = (post: BlogPost) => {
   let html = ""
 
   if (authors) {
-    html += `<p style="font-style: italic; margin-bottom: 1.5rem; color: #6b7280;">${
+    html += `<p style="font-style: italic; margin-bottom: 1.5rem; color: #4b5563;">${
       post.authors.length > 1 ? "Authors" : "Author"
     }: ${escapeHtml(authors)}</p>`
   }

--- a/lib/rss/index.ts
+++ b/lib/rss/index.ts
@@ -30,7 +30,7 @@ const renderPostContent = (post: BlogPost) => {
   let html = ""
 
   if (authors) {
-    html += `<p style="font-style: italic; margin-bottom: 1.5rem; color: #4b5563;">${
+    html += `<p style="font-style: italic; margin-bottom: 1.5rem; color: #6b7280;">${
       post.authors.length > 1 ? "Authors" : "Author"
     }: ${escapeHtml(authors)}</p>`
   }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import usePostHog from "@hooks/usePostHog"
 import "@styles/globals.css"
 import { ThemeProvider } from "next-themes"
 import type { AppProps } from "next/app"
-import { Inter, IBM_Plex_Serif } from "next/font/google"
+import { Inter, IBM_Plex_Serif, JetBrains_Mono } from "next/font/google"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -13,6 +13,11 @@ const ibmPlexSerif = IBM_Plex_Serif({
   weight: ["400", "500", "600", "700"],
   subsets: ["latin"],
   variable: "--font-serif",
+})
+const jetBrainsMono = JetBrains_Mono({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
 })
 
 const RailwayBlog = ({ Component, pageProps }: AppProps) => {
@@ -26,7 +31,9 @@ const RailwayBlog = ({ Component, pageProps }: AppProps) => {
       disableTransitionOnChange={true}
       enableSystem
     >
-      <div className={`${inter.variable} ${ibmPlexSerif.variable} font-sans`}>
+      <div
+        className={`${inter.variable} ${ibmPlexSerif.variable} ${jetBrainsMono.variable} font-sans`}
+      >
         <Component {...pageProps} />
       </div>
     </ThemeProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,10 +3,12 @@ import usePostHog from "@hooks/usePostHog"
 import "@styles/globals.css"
 import { ThemeProvider } from "next-themes"
 import type { AppProps } from "next/app"
-import Head from "next/head"
 import { Inter, IBM_Plex_Serif } from "next/font/google"
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+})
 const ibmPlexSerif = IBM_Plex_Serif({
   weight: ["400", "500", "600", "700"],
   subsets: ["latin"],
@@ -24,15 +26,7 @@ const RailwayBlog = ({ Component, pageProps }: AppProps) => {
       disableTransitionOnChange={true}
       enableSystem
     >
-      <Head>
-        <style jsx global>{`
-          html {
-            font-family: ${inter.style.fontFamily};
-          }
-        `}</style>
-      </Head>
-
-      <div className={ibmPlexSerif.variable}>
+      <div className={`${inter.variable} ${ibmPlexSerif.variable} font-sans`}>
         <Component {...pageProps} />
       </div>
     </ThemeProvider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,6 +15,17 @@ body {
   min-height: 100vh;
 }
 
+b,
+strong,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-semibold;
+}
+
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -44,6 +44,12 @@ h6 {
   white-space: nowrap;
 }
 
+.dark .inline-code {
+  color: #a667e4;
+  background-color: #1d182c;
+  border-color: #2f2547;
+}
+
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,14 +26,59 @@ h6 {
   @apply font-semibold;
 }
 
-.light .post-category-pill {
-  color: #5d487d;
-  background-color: #ddd7e4;
+.post-category-pill {
+  color: var(--category-badge-text);
+  background-color: var(--category-badge-fill);
 }
 
-.dark .post-category-pill {
-  color: #a98fce;
-  background-color: #2f2547;
+.light .post-category-pill[data-category-tone="plum"] {
+  --category-badge-fill: #dbd7de;
+  --category-badge-text: #5d487d;
+}
+
+.dark .post-category-pill[data-category-tone="plum"] {
+  --category-badge-fill: #3a314c;
+  --category-badge-text: #b9a3d8;
+}
+
+.light .post-category-pill[data-category-tone="gold"] {
+  --category-badge-fill: #e8e1d5;
+  --category-badge-text: #795e2f;
+}
+
+.dark .post-category-pill[data-category-tone="gold"] {
+  --category-badge-fill: #4c4032;
+  --category-badge-text: #d5b886;
+}
+
+.light .post-category-pill[data-category-tone="teal"] {
+  --category-badge-fill: #d7e6e7;
+  --category-badge-text: #2b6c73;
+}
+
+.dark .post-category-pill[data-category-tone="teal"] {
+  --category-badge-fill: #2d4951;
+  --category-badge-text: #66c2cc;
+}
+
+.light .post-category-pill[data-category-tone="blue"] {
+  --category-badge-fill: #d9dce4;
+  --category-badge-text: #4c5d94;
+}
+
+.dark .post-category-pill[data-category-tone="blue"] {
+  --category-badge-fill: #31364c;
+  --category-badge-text: #93a1cc;
+}
+
+.light .post-category-pill[data-category-tone="wine"] {
+  --category-badge-fill: #e6d8db;
+  --category-badge-text: #8d495d;
+}
+
+.dark .post-category-pill[data-category-tone="wine"] {
+  --category-badge-fill: #48313d;
+  --category-badge-text: #cc93a5;
 }
 
 .inline-code {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -81,6 +81,33 @@ h6 {
   --category-badge-text: #cc93a5;
 }
 
+.light .load-more-posts {
+  color: #5d487d;
+  background-color: #dbd7de;
+  border-color: #dbd7de;
+}
+
+.dark .load-more-posts {
+  color: #b9a3d8;
+  background-color: #3a314c;
+  border-color: #3a314c;
+}
+
+.light .load-more-posts:hover {
+  color: #37334c;
+  border-color: #7156aa;
+}
+
+.dark .load-more-posts:hover {
+  color: #c0c0d0;
+  border-color: #b9a3d8;
+}
+
+.load-more-posts:focus-visible {
+  outline: 2px solid #7156aa;
+  outline-offset: 2px;
+}
+
 .inline-code {
   color: #37334c;
   background-color: #e4e1e8;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -108,6 +108,51 @@ h6 {
   outline-offset: 2px;
 }
 
+.light .post-bottom-cta {
+  background-color: #ebe8ee;
+  border-color: #dbd7de;
+}
+
+.dark .post-bottom-cta {
+  background-color: #1d182c;
+  border-color: #3a314c;
+}
+
+.post-bottom-cta-primary {
+  color: #ffffff;
+  background-color: #5d487d;
+}
+
+.post-bottom-cta-primary:hover {
+  background-color: #7156aa;
+}
+
+.light .post-bottom-cta-secondary {
+  color: #37334c;
+  border-color: #d0c8dd;
+}
+
+.dark .post-bottom-cta-secondary {
+  color: #c0c0d0;
+  border-color: #3a314c;
+}
+
+.light .post-bottom-cta-secondary:hover {
+  background-color: #dbd7de;
+  border-color: #7156aa;
+}
+
+.dark .post-bottom-cta-secondary:hover {
+  background-color: #3a314c;
+  border-color: #b9a3d8;
+}
+
+.post-bottom-cta-primary:focus-visible,
+.post-bottom-cta-secondary:focus-visible {
+  outline: 2px solid #7156aa;
+  outline-offset: 2px;
+}
+
 .inline-code {
   color: #37334c;
   background-color: #e4e1e8;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,6 +31,11 @@ h6 {
   background-color: #ddd7e4;
 }
 
+.dark .post-category-pill {
+  color: #a98fce;
+  background-color: #2f2547;
+}
+
 .inline-code {
   color: #37334c;
   background-color: #e4e1e8;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,6 +26,11 @@ h6 {
   @apply font-semibold;
 }
 
+.light .homepage-category-pill {
+  color: #5d487d;
+  background-color: #ddd7e4;
+}
+
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,7 +26,7 @@ h6 {
   @apply font-semibold;
 }
 
-.light .homepage-category-pill {
+.light .post-category-pill {
   color: #5d487d;
   background-color: #ddd7e4;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -60,8 +60,8 @@ h6 {
 }
 
 .dark .markdown-inline-link {
-  color: #a667e4;
-  text-decoration-color: rgb(166 103 228 / 45%);
+  color: #a98fce;
+  text-decoration-color: rgb(169 143 206 / 45%);
 }
 
 .markdown-inline-link:hover {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,6 +31,19 @@ h6 {
   background-color: #ddd7e4;
 }
 
+.inline-code {
+  color: #37334c;
+  background-color: #e4e1e8;
+  border: 1px solid #d0c8dd;
+  border-radius: 5px;
+  padding: 0.1em 0.36em;
+  font-family: var(--font-jetbrains-mono), "JetBrains Mono", monospace;
+  font-size: 0.82em;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,6 +10,7 @@ html,
 body {
   @apply antialiased;
   @apply bg-background text-foreground;
+  @apply text-base font-normal tracking-normal;
 
   min-height: 100vh;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,6 +50,34 @@ h6 {
   border-color: #2f2547;
 }
 
+.markdown-inline-link {
+  color: #5d487d;
+  font-weight: 400;
+  text-decoration-line: underline;
+  text-decoration-color: rgb(93 72 125 / 45%);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.dark .markdown-inline-link {
+  color: #a667e4;
+  text-decoration-color: rgb(166 103 228 / 45%);
+}
+
+.markdown-inline-link:hover {
+  color: #37334c;
+  text-decoration-color: currentColor;
+}
+
+.dark .markdown-inline-link:hover {
+  color: #c0c0d0;
+}
+
+.markdown-inline-link:focus-visible {
+  outline: 2px solid #7156aa;
+  outline-offset: 2px;
+}
+
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,7 +124,7 @@ module.exports = {
             },
 
             p: {
-              color: theme("colors.gray.800"),
+              color: theme("colors.gray.600"),
 
               a: {
                 textDecoration: "underline",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,7 @@ const customColors = {
 }
 
 const fontStack = [
+  "var(--font-inter)",
   "Inter",
   "-apple-system",
   "BlinkMacSystemFont",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,7 +124,7 @@ module.exports = {
             },
 
             p: {
-              color: theme("colors.gray.600"),
+              color: theme("colors.gray.800"),
 
               a: {
                 textDecoration: "underline",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -87,6 +87,7 @@ module.exports = {
       },
       fontSize: {
         // Headings
+        "post-title": ["48px", "56px"],
         huge: ["clamp(48px, 6vw, 64px)", "1.25"],
         jumbo: ["clamp(40px, 5vw, 48px)", "1.25"],
         large: ["clamp(32px, 4vw, 40px)", "1.25"],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -78,6 +78,13 @@ module.exports = {
         current: "currentColor",
         black: colors.black,
         white: colors.white,
+        plum: {
+          200: "#C0C0D0",
+          300: "#A667E4",
+          400: "#7156AA",
+          500: "#5D487D",
+          600: "#37334C",
+        },
         ...customColors,
       },
       backgroundImage: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -87,7 +87,10 @@ module.exports = {
       },
       fontSize: {
         // Headings
-        "post-title": ["48px", "56px"],
+        "post-title": [
+          "48px",
+          { lineHeight: "56px", letterSpacing: "-0.02em" },
+        ],
         huge: ["clamp(48px, 6vw, 64px)", "1.25"],
         jumbo: ["clamp(40px, 5vw, 48px)", "1.25"],
         large: ["clamp(32px, 4vw, 40px)", "1.25"],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -95,8 +95,22 @@ module.exports = {
         jumbo: ["clamp(40px, 5vw, 48px)", "1.25"],
         large: ["clamp(32px, 4vw, 40px)", "1.25"],
         h1: ["clamp(28px, 2.5vw, 32px)", "1.375"],
-        h2: ["clamp(24px, 3vw, 28px)", "1.375"],
-        h3: ["clamp(22px, 2.5vw, 24px)", "1.375"],
+        h2: [
+          "32px",
+          {
+            lineHeight: "40px",
+            letterSpacing: "-0.02em",
+            fontWeight: "500",
+          },
+        ],
+        h3: [
+          "24px",
+          {
+            lineHeight: "32px",
+            letterSpacing: "-0.02em",
+            fontWeight: "500",
+          },
+        ],
         h4: ["20px", "1.375"],
         h5: ["18px", "1.5"],
         h6: ["16px", "1.5"],

--- a/test/components/BottomCTA.test.tsx
+++ b/test/components/BottomCTA.test.tsx
@@ -14,7 +14,7 @@ describe("BottomCTA", () => {
 
     expect(
       getByRole("link", { name: "Deploy a new project" }).getAttribute("href")
-    ).toBe("https://dev.new")
+    ).toBe("https://railway.com")
     expect(
       getByRole("link", { name: "Book a demo" }).getAttribute("href")
     ).toBe("https://railway.com/enterprise")

--- a/test/components/BottomCTA.test.tsx
+++ b/test/components/BottomCTA.test.tsx
@@ -1,0 +1,22 @@
+import { BottomCTA } from "@components/BottomCTA"
+import React from "react"
+import { render } from "../testUtils"
+
+describe("BottomCTA", () => {
+  it("renders the updated copy and actions", () => {
+    const { getByRole, getByText, queryByText } = render(<BottomCTA />)
+
+    expect(getByRole("heading", { name: "Ready to get started?" })).toBeTruthy()
+    expect(
+      getByText("Join millions of developers deploying applications on Railway")
+    ).toBeTruthy()
+    expect(queryByText("Your train has arrived!")).toBeNull()
+
+    expect(
+      getByRole("link", { name: "Deploy a new project" }).getAttribute("href")
+    ).toBe("https://dev.new")
+    expect(
+      getByRole("link", { name: "Book a demo" }).getAttribute("href")
+    ).toBe("https://railway.com/enterprise")
+  })
+})

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -295,4 +295,13 @@ describe("MarkdownContent typography", () => {
     expect(container.querySelector("p")?.className).not.toContain("leading-")
     expect(container.querySelector("li")?.className).not.toContain("leading-")
   })
+
+  it("uses the H2 and H3 type tokens for article headings", () => {
+    const { getByRole } = render(
+      <MarkdownContent content={"## Section heading\n\n### Subheading"} />
+    )
+
+    expect(getByRole("heading", { level: 2 }).className).toContain("text-h2")
+    expect(getByRole("heading", { level: 3 }).className).toContain("text-h3")
+  })
 })

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -289,11 +289,15 @@ describe("MarkdownContent ordered lists", () => {
 describe("MarkdownContent typography", () => {
   it("inherits the body token line-height for paragraphs and list items", () => {
     const { container } = render(
-      <MarkdownContent content={"A paragraph.\n\n- A list item."} />
+      <MarkdownContent
+        content={"A paragraph.\n\n- A list item.\n\n1. An ordered item."}
+      />
     )
 
     expect(container.querySelector("p")?.className).not.toContain("leading-")
     expect(container.querySelector("li")?.className).not.toContain("leading-")
+    expect(container.querySelector("ul")?.className).toContain("text-gray-800")
+    expect(container.querySelector("ol")?.className).toContain("text-gray-800")
   })
 
   it("uses the H2 and H3 type tokens for article headings", () => {

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -287,11 +287,12 @@ describe("MarkdownContent ordered lists", () => {
 })
 
 describe("MarkdownContent typography", () => {
-  it("inherits the body token line-height for paragraphs and list items", () => {
+  it("uses the gray-600 body tone and token line-height", () => {
     const { container } = render(
       <MarkdownContent content={"A paragraph.\n\n- A list item."} />
     )
 
+    expect(container.firstElementChild?.className).toContain("text-gray-600")
     expect(container.querySelector("p")?.className).not.toContain("leading-")
     expect(container.querySelector("li")?.className).not.toContain("leading-")
   })

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -298,6 +298,9 @@ describe("MarkdownContent typography", () => {
     expect(container.querySelector("li")?.className).not.toContain("leading-")
     expect(container.querySelector("ul")?.className).toContain("text-gray-800")
     expect(container.querySelector("ol")?.className).toContain("text-gray-800")
+    expect(container.querySelector("ul")?.className).toContain("space-y-4")
+    expect(container.querySelector("ol")?.className).toContain("space-y-4")
+    expect(container.querySelector("li")?.className).not.toContain("mb-")
   })
 
   it("uses the H2 and H3 type tokens for article headings", () => {

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -285,3 +285,14 @@ describe("MarkdownContent ordered lists", () => {
     expect(lists[1].getAttribute("start")).toBe("3")
   })
 })
+
+describe("MarkdownContent typography", () => {
+  it("inherits the body token line-height for paragraphs and list items", () => {
+    const { container } = render(
+      <MarkdownContent content={"A paragraph.\n\n- A list item."} />
+    )
+
+    expect(container.querySelector("p")?.className).not.toContain("leading-")
+    expect(container.querySelector("li")?.className).not.toContain("leading-")
+  })
+})

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -287,6 +287,21 @@ describe("MarkdownContent ordered lists", () => {
 })
 
 describe("MarkdownContent typography", () => {
+  it("uses the inline-code treatment without affecting fenced blocks", () => {
+    const { container } = render(
+      <MarkdownContent
+        content={"Run `railway up`.\n\n```bash\nrailway up\n```"}
+      />
+    )
+
+    expect(container.querySelector("p code")?.className).toContain(
+      "inline-code"
+    )
+    expect(container.querySelector("pre code")?.className).not.toContain(
+      "inline-code"
+    )
+  })
+
   it("inherits the body token line-height for paragraphs and list items", () => {
     const { container } = render(
       <MarkdownContent

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -187,6 +187,7 @@ describe("MarkdownContent embed links", () => {
 
     const caption = container.querySelector("figcaption")
     expect(caption?.textContent).toBe("Our CDN POPs as displayed by our DCIM tooling")
+    expect(container.querySelector("img")?.className).toContain("rounded-[4px]")
   })
 
   it("does not render filename alt text as a caption", () => {

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -287,12 +287,11 @@ describe("MarkdownContent ordered lists", () => {
 })
 
 describe("MarkdownContent typography", () => {
-  it("uses the gray-600 body tone and token line-height", () => {
+  it("inherits the body token line-height for paragraphs and list items", () => {
     const { container } = render(
       <MarkdownContent content={"A paragraph.\n\n- A list item."} />
     )
 
-    expect(container.firstElementChild?.className).toContain("text-gray-600")
     expect(container.querySelector("p")?.className).not.toContain("leading-")
     expect(container.querySelector("li")?.className).not.toContain("leading-")
   })

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -287,6 +287,16 @@ describe("MarkdownContent ordered lists", () => {
 })
 
 describe("MarkdownContent typography", () => {
+  it("uses the themed inline-link treatment", () => {
+    const { getByRole } = render(
+      <MarkdownContent content={"Read the [Railway docs](https://docs.railway.com)."} />
+    )
+
+    expect(getByRole("link", { name: "Railway docs" }).className).toContain(
+      "markdown-inline-link"
+    )
+  })
+
   it("uses the inline-code treatment without affecting fenced blocks", () => {
     const { container } = render(
       <MarkdownContent

--- a/test/components/MarkdownContent.test.tsx
+++ b/test/components/MarkdownContent.test.tsx
@@ -187,7 +187,7 @@ describe("MarkdownContent embed links", () => {
 
     const caption = container.querySelector("figcaption")
     expect(caption?.textContent).toBe("Our CDN POPs as displayed by our DCIM tooling")
-    expect(container.querySelector("img")?.className).toContain("rounded-[4px]")
+    expect(container.querySelector("img")?.className).toContain("rounded-[8px]")
   })
 
   it("does not render filename alt text as a caption", () => {

--- a/test/components/PostCategory.test.tsx
+++ b/test/components/PostCategory.test.tsx
@@ -1,0 +1,22 @@
+import { PostCategory } from "@components/PostCategory"
+import React from "react"
+import { render } from "../testUtils"
+
+describe("PostCategory palette", () => {
+  it.each([
+    ["Engineering", "plum"],
+    ["News", "gold"],
+    ["AI", "teal"],
+    ["Guide", "blue"],
+    ["Company", "wine"],
+    ["Unknown", "plum"],
+  ])("maps %s to the %s tone", (categoryName, tone) => {
+    const { getByText } = render(
+      <PostCategory category={categoryName} isCommunity={false} />
+    )
+
+    expect(getByText(categoryName).getAttribute("data-category-tone")).toBe(
+      tone
+    )
+  })
+})

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -128,14 +128,42 @@ describe("PostList typography", () => {
     expect(getByRole("heading", { level: 3 }).className).toContain("text-h3")
   })
 
+  it("uses the homepage category-pill treatment", () => {
+    const featuredPost = { ...makePost(1), featured: true }
+    const standardPost = makePost(2)
+    const { container, rerender } = render(
+      <PostList posts={[featuredPost, standardPost]} categories={[]} />
+    )
+
+    const pills = container.querySelectorAll(".homepage-category-pill")
+    expect(pills).toHaveLength(2)
+    pills.forEach((pill) => {
+      expect(pill.className).toContain("text-xs")
+      expect(pill.className).toContain("uppercase")
+      expect(pill.className).not.toContain("font-mono")
+      expect(pill.className).toContain("tracking-[0.06em]")
+      expect(pill.className).toContain("px-2")
+      expect(pill.className).toContain("py-[3px]")
+      expect(pill.className).toContain("rounded-[6px]")
+    })
+
+    rerender(
+      <PostList
+        posts={[featuredPost, standardPost]}
+        categories={[]}
+        category={category}
+      />
+    )
+    expect(container.querySelectorAll(".homepage-category-pill")).toHaveLength(
+      0
+    )
+  })
+
   it("uses the secondary tone for featured and standard descriptions", () => {
     const featuredPost = { ...makePost(1), featured: true }
     const standardPost = makePost(2)
     const { getByText } = render(
-      <PostList
-        posts={[featuredPost, standardPost]}
-        categories={[]}
-      />
+      <PostList posts={[featuredPost, standardPost]} categories={[]} />
     )
 
     expect(getByText("Description 1").className).toContain(

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -114,6 +114,28 @@ describe("PostList heading semantics", () => {
     expect(queryByRole("heading", { level: 1 })).toBeNull()
     expect(getByRole("heading", { level: 2 }).textContent).toBe("Everything")
   })
+
+  it("places homepage and category headings above a three-column post grid", () => {
+    const { getByRole, rerender } = render(
+      <PostList posts={posts} categories={[]} />
+    )
+
+    const expectHeadingAboveGrid = (level: 1 | 2) => {
+      const heading = getByRole("heading", { level })
+      const grid = heading.nextElementSibling
+
+      expect(heading.parentElement?.className).not.toContain("lg:grid-cols-3")
+      expect(grid?.className).toContain("lg:grid-cols-3")
+      expect(grid?.className).not.toContain("lg:col-span-2")
+    }
+
+    expectHeadingAboveGrid(2)
+
+    rerender(
+      <PostList posts={posts} categories={[]} category={category} />
+    )
+    expectHeadingAboveGrid(1)
+  })
 })
 
 describe("PostList typography", () => {

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -65,7 +65,7 @@ describe("PostList crawlable links", () => {
       <PostList posts={posts} categories={[]} category={category} />
     )
 
-    fireEvent.click(getByText("Load more posts..."))
+    fireEvent.click(getByText("Load more posts"))
 
     expect(container.querySelector("ul.hidden")).toBeNull()
     const hrefs = Array.from(

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -40,18 +40,21 @@ describe("PostList crawlable links", () => {
       <PostList posts={posts} categories={[]} category={category} />
     )
 
-    const hrefs = Array.from(
-      container.querySelectorAll('a[href^="/p/"]')
-    ).map((a) => a.getAttribute("href"))
+    const hrefs = Array.from(container.querySelectorAll('a[href^="/p/"]')).map(
+      (a) => a.getAttribute("href")
+    )
     for (let i = 1; i <= 12; i++) {
       expect(hrefs).toContain(`/p/post-${i}`)
     }
 
     const hidden = container.querySelector("ul.hidden")
     expect(hidden).not.toBeNull()
-    const hiddenHrefs = Array.from(
-      hidden!.querySelectorAll("a")
-    ).map((a) => a.getAttribute("href"))
+    if (hidden == null) {
+      throw new Error("Expected hidden crawlable post links")
+    }
+    const hiddenHrefs = Array.from(hidden.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href")
+    )
     expect(hiddenHrefs).toEqual([
       "/p/post-9",
       "/p/post-10",
@@ -60,20 +63,42 @@ describe("PostList crawlable links", () => {
     ])
   })
 
-  it("replaces the hidden list with full cards on Load more", () => {
-    const { container, getByText } = render(
-      <PostList posts={posts} categories={[]} category={category} />
+  it("reveals six posts at a time until every card is visible", () => {
+    const manyPosts = Array.from({ length: 22 }, (_, i) => makePost(i + 1))
+    const { container, getByRole, queryByRole } = render(
+      <PostList posts={manyPosts} categories={[]} category={category} />
     )
+    const postsGrid = getByRole("button", {
+      name: "Load more posts",
+    }).parentElement
+    if (postsGrid == null) {
+      throw new Error("Expected the posts grid")
+    }
+    const visiblePostLinks = () =>
+      Array.from(postsGrid.children).filter(
+        (child) =>
+          child instanceof HTMLAnchorElement &&
+          child.getAttribute("href")?.startsWith("/p/")
+      )
+    const hiddenPostLinks = () =>
+      container.querySelectorAll('ul.hidden a[href^="/p/"]')
 
-    fireEvent.click(getByText("Load more posts"))
+    expect(visiblePostLinks()).toHaveLength(8)
+    expect(hiddenPostLinks()).toHaveLength(14)
 
+    fireEvent.click(getByRole("button", { name: "Load more posts" }))
+    expect(visiblePostLinks()).toHaveLength(14)
+    expect(hiddenPostLinks()).toHaveLength(8)
+
+    fireEvent.click(getByRole("button", { name: "Load more posts" }))
+    expect(visiblePostLinks()).toHaveLength(20)
+    expect(hiddenPostLinks()).toHaveLength(2)
+
+    fireEvent.click(getByRole("button", { name: "Load more posts" }))
+    expect(visiblePostLinks()).toHaveLength(22)
     expect(container.querySelector("ul.hidden")).toBeNull()
-    const hrefs = Array.from(
-      container.querySelectorAll('a[href^="/p/"]')
-    ).map((a) => a.getAttribute("href"))
-    expect(hrefs).toHaveLength(12)
+    expect(queryByRole("button", { name: "Load more posts" })).toBeNull()
   })
-
 })
 
 describe("PostList heading semantics", () => {
@@ -135,17 +160,15 @@ describe("PostList heading semantics", () => {
     }
 
     expectHeadingAboveGrid(2)
-    expect(getByRole("heading", { level: 2 }).parentElement?.className).toContain(
-      "mt-16"
-    )
+    expect(
+      getByRole("heading", { level: 2 }).parentElement?.className
+    ).toContain("mt-16")
 
-    rerender(
-      <PostList posts={posts} categories={[]} category={category} />
-    )
+    rerender(<PostList posts={posts} categories={[]} category={category} />)
     expectHeadingAboveGrid(1)
-    expect(getByRole("heading", { level: 1 }).parentElement?.className).toContain(
-      "mt-24"
-    )
+    expect(
+      getByRole("heading", { level: 1 }).parentElement?.className
+    ).toContain("mt-24")
   })
 })
 

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -179,6 +179,8 @@ describe("PostList typography", () => {
         expect(pill.className).toContain("px-2")
         expect(pill.className).toContain("py-[3px]")
         expect(pill.className).toContain("rounded-[4px]")
+        expect(pill.className).not.toMatch(/text-(blue|green|pink|gray)-/)
+        expect(pill.className).not.toMatch(/bg-(blue|green|pink|gray)-/)
       })
     }
 

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -135,11 +135,17 @@ describe("PostList heading semantics", () => {
     }
 
     expectHeadingAboveGrid(2)
+    expect(getByRole("heading", { level: 2 }).parentElement?.className).toContain(
+      "mt-16"
+    )
 
     rerender(
       <PostList posts={posts} categories={[]} category={category} />
     )
     expectHeadingAboveGrid(1)
+    expect(getByRole("heading", { level: 1 }).parentElement?.className).toContain(
+      "mt-24"
+    )
   })
 })
 

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -161,24 +161,28 @@ describe("PostList typography", () => {
     expect(getByRole("heading", { level: 3 }).className).toContain("text-h3")
   })
 
-  it("uses the homepage category-pill treatment", () => {
+  it("uses one shared category-pill treatment on every listing page", () => {
     const featuredPost = { ...makePost(1), featured: true }
     const standardPost = makePost(2)
     const { container, rerender } = render(
       <PostList posts={[featuredPost, standardPost]} categories={[]} />
     )
 
-    const pills = container.querySelectorAll(".homepage-category-pill")
-    expect(pills).toHaveLength(2)
-    pills.forEach((pill) => {
-      expect(pill.className).toContain("text-xs")
-      expect(pill.className).toContain("uppercase")
-      expect(pill.className).not.toContain("font-mono")
-      expect(pill.className).toContain("tracking-[0.06em]")
-      expect(pill.className).toContain("px-2")
-      expect(pill.className).toContain("py-[3px]")
-      expect(pill.className).toContain("rounded-[4px]")
-    })
+    const expectSharedPillTreatment = () => {
+      const pills = container.querySelectorAll(".post-category-pill")
+      expect(pills).toHaveLength(2)
+      pills.forEach((pill) => {
+        expect(pill.className).toContain("text-xs")
+        expect(pill.className).toContain("uppercase")
+        expect(pill.className).not.toContain("font-mono")
+        expect(pill.className).toContain("tracking-[0.06em]")
+        expect(pill.className).toContain("px-2")
+        expect(pill.className).toContain("py-[3px]")
+        expect(pill.className).toContain("rounded-[4px]")
+      })
+    }
+
+    expectSharedPillTreatment()
 
     rerender(
       <PostList
@@ -187,9 +191,7 @@ describe("PostList typography", () => {
         category={category}
       />
     )
-    expect(container.querySelectorAll(".homepage-category-pill")).toHaveLength(
-      0
-    )
+    expectSharedPillTreatment()
   })
 
   it("uses the secondary tone for featured and standard descriptions", () => {

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -112,3 +112,23 @@ describe("PostList heading semantics", () => {
     expect(getByRole("heading", { level: 2 }).textContent).toBe("Everything")
   })
 })
+
+describe("PostList typography", () => {
+  it("uses the secondary tone for featured and standard descriptions", () => {
+    const featuredPost = { ...makePost(1), featured: true }
+    const standardPost = makePost(2)
+    const { getByText } = render(
+      <PostList
+        posts={[featuredPost, standardPost]}
+        categories={[]}
+      />
+    )
+
+    expect(getByText("Description 1").className).toContain(
+      "text-lg text-gray-600"
+    )
+    expect(getByText("Description 2").className).toContain(
+      "text-base text-gray-600"
+    )
+  })
+})

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -88,7 +88,7 @@ describe("PostList heading semantics", () => {
     expect(heading.className).not.toContain("font-bold")
   })
 
-  it("renders the h1 even when every post in the category is featured", () => {
+  it("renders featured category posts as standard cards below the h1", () => {
     const featuredOnly = posts.slice(0, 2).map((post) => ({
       ...post,
       featured: true,
@@ -98,11 +98,16 @@ describe("PostList heading semantics", () => {
         alt: "cover",
       },
     }))
-    const { getByRole, container } = render(
+    const { getByRole, queryByRole, container } = render(
       <PostList posts={featuredOnly} categories={[]} category={category} />
     )
 
-    expect(getByRole("heading", { level: 1 }).textContent).toBeTruthy()
+    const heading = getByRole("heading", { level: 1 })
+    const standardGrid = heading.nextElementSibling
+
+    expect(queryByRole("heading", { level: 3 })).toBeNull()
+    expect(standardGrid?.querySelectorAll('a[href^="/p/"]')).toHaveLength(2)
+    expect(container.querySelector('img[alt="cover"]')).toBeNull()
     expect(container.querySelector("ul.hidden")).toBeNull()
   })
 

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -144,7 +144,7 @@ describe("PostList typography", () => {
       expect(pill.className).toContain("tracking-[0.06em]")
       expect(pill.className).toContain("px-2")
       expect(pill.className).toContain("py-[3px]")
-      expect(pill.className).toContain("rounded-[6px]")
+      expect(pill.className).toContain("rounded-[4px]")
     })
 
     rerender(

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -114,6 +114,17 @@ describe("PostList heading semantics", () => {
 })
 
 describe("PostList typography", () => {
+  it("uses the H2 and H3 type tokens on the homepage", () => {
+    const featuredPost = { ...makePost(1), featured: true }
+    const standardPost = makePost(2)
+    const { getByRole } = render(
+      <PostList posts={[featuredPost, standardPost]} categories={[]} />
+    )
+
+    expect(getByRole("heading", { level: 2 }).className).toContain("text-h2")
+    expect(getByRole("heading", { level: 3 }).className).toContain("text-h3")
+  })
+
   it("uses the secondary tone for featured and standard descriptions", () => {
     const featuredPost = { ...makePost(1), featured: true }
     const standardPost = makePost(2)

--- a/test/components/PostList.test.tsx
+++ b/test/components/PostList.test.tsx
@@ -82,7 +82,10 @@ describe("PostList heading semantics", () => {
       <PostList posts={posts} categories={[]} category={category} />
     )
 
-    expect(getByRole("heading", { level: 1 }).textContent).toBeTruthy()
+    const heading = getByRole("heading", { level: 1 })
+    expect(heading.textContent).toBeTruthy()
+    expect(heading.className).toContain("font-semibold")
+    expect(heading.className).not.toContain("font-bold")
   })
 
   it("renders the h1 even when every post in the category is featured", () => {


### PR DESCRIPTION
## What

Aligns blog body copy and post titles with the audited Railway marketing type system.

## Changes

- Use the Next-managed Inter font through `--font-inter` and establish a 16/24, weight-400, normal-tracking body baseline.
- Bring article paragraphs and list items to the tokenized 1.5 line-height rhythm across desktop and mobile.
- Set post titles to a named 48/56 display token, following the 8px grid rhythm.
- Use the AA-safe `gray-600` secondary tone and intended weights for feed descriptions, metadata, categories, labels, and footer copy.
- Add warning-level ESLint guardrails and regression coverage for article and home-feed typography.

## Verification

- `./node_modules/.bin/eslint . --ext ts --ext tsx --ext js` (0 errors; 2 existing warnings)
- `./node_modules/.bin/tsc --pretty --noEmit`
- `./node_modules/.bin/jest test/components/PostList.test.tsx test/components/Categories.test.tsx --runInBand` (8 tests)
- Manually verified article body at 18/27 on desktop and 16/24 at 390px with no horizontal overflow.
- Manually verified post titles at 48/56 on desktop and mobile, with the 736px article column preserved on the 8px grid and no horizontal overflow.
- Manually verified secondary text contrast at 4.58:1 in light mode and 6.91:1 in dark mode.
- Manually verified featured and standard home-feed descriptions at 18/27 and 16/24 respectively.

Full Jest was also attempted; it remains blocked locally by the existing Jest 27/ESM `react-markdown` parsing issue and an unrelated `buildMetaDescription` assertion.
