### PR TITLE
Fix markdown post routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,5 +15,21 @@ module.exports = {
   outputFileTracingRoot: __dirname,
   poweredByHeader: false,
   reactStrictMode: true,
-  staticPageGenerationTimeout: 300
+  staticPageGenerationTimeout: 300,
+  async rewrites() {
+    return {
+      // A dynamic page named `[slug].md` is compiled by Next with the same
+      // route regex as `[slug]`, so `/p/example.md` is otherwise handled as an
+      // HTML post whose slug is `example.md`. Rewrite before filesystem route
+      // matching to keep the public `.md` URL while using an unambiguous page.
+      beforeFiles: [
+        {
+          source: "/p/:slug.md",
+          destination: "/p/:slug/markdown",
+        },
+      ],
+      afterFiles: [],
+      fallback: [],
+    }
+  },
 }

--- a/pages/p/[slug]/markdown.tsx
+++ b/pages/p/[slug]/markdown.tsx
@@ -4,9 +4,9 @@ import { GetServerSideProps } from "next"
 const ROOT_URL = "https://blog.railway.com"
 
 /**
- * Markdown twin of /p/{slug}. Serves the post's full content as
- * text/markdown with YAML front-matter so LLMs and markdown-preferring
- * clients get the same payload the HTML page serves.
+ * Internal target for the public /p/{slug}.md rewrite. Serves the post's full
+ * content as text/markdown with YAML front-matter so LLMs and
+ * markdown-preferring clients get the same payload the HTML page serves.
  */
 export const getServerSideProps: GetServerSideProps = async ({
   params,
@@ -38,7 +38,10 @@ export const getServerSideProps: GetServerSideProps = async ({
   const authors = post.authors.map((a) => a.name).filter(Boolean)
 
   const yamlQuote = (value: string) =>
-    `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`
+    `"${value
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, "\\n")}"`
 
   const parts: string[] = []
 

--- a/test/next-config.test.js
+++ b/test/next-config.test.js
@@ -1,0 +1,12 @@
+const nextConfig = require("../next.config")
+
+describe("markdown post rewrite", () => {
+  it("runs before the dynamic HTML post route", async () => {
+    const rewrites = await nextConfig.rewrites()
+
+    expect(rewrites.beforeFiles).toContainEqual({
+      source: "/p/:slug.md",
+      destination: "/p/:slug/markdown",
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- route public `/p/:slug.md` requests through a `beforeFiles` rewrite
- move the markdown response handler to an unambiguous internal route
- add a regression test that keeps the rewrite ahead of the HTML post route

## Why

Next.js compiles `pages/p/[slug].md/index.tsx` with the same route regex as `pages/p/[slug].tsx`. As a result, requests such as `/p/dev-new.md` reached the HTML handler with `dev-new.md` as the slug and returned a cached 404.

## Testing

- `npm run type-check`
- `npm run build`
- `npm test -- test/next-config.test.js --runInBand`
- ESLint and Prettier checks on changed files
- production-build smoke test: `/p/dev-new.md` returns `200` with `Content-Type: text/markdown`; `/p/dev-new` remains `200` HTML

The full test suite has unrelated existing failures in `test/seo-components.test.ts`, `test/pages/not-found-revalidate.test.ts`, and `test/components/MarkdownContent.test.tsx`.