### PR TITLE
Support CMS draft preview links for blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ CMS_API_URL=https://cms.railway.com
 
 The CMS API key must stay server-only. Do not expose it through a `NEXT_PUBLIC_*` variable.
 
+## Draft previews
+
+The CMS post editor can share a seven-day link to the latest saved draft at
+`/p/{slug}?cmsPreview={token}`. Middleware routes these requests to an uncached
+server-rendered preview. The CMS validates the document-scoped token on every
+request, including replacement, revocation, expiry, and slug/archive changes.
+Preview reads use `CMS_API_URL` without the published-content API key or an
+additional signing secret. Invalid links return 404; upstream failures return 503.
+
+Preview pages disable indexing, referrers, article metadata, and analytics.
+Feeds, sitemaps, and Markdown/LLM exports continue reading published content only.
+Deploy this reader before the CMS adds `posts` to its shared preview collections.
+For local end-to-end testing, point the CMS's `CMS_BLOG_PREVIEW_ORIGIN` at
+`http://localhost:3002` and the blog's `CMS_API_URL` at that CMS instance.
+
 ## Running Locally
 
 - Make sure you have `yarn`.

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -19,6 +19,7 @@ export interface Props extends NextSeoProps {
   content?: string | null
   currentUrl?: string
   alternateMarkdownHref?: string
+  preview?: boolean
 }
 
 // Raw JSON.stringify output is unsafe inside a <script>: a CMS-authored
@@ -50,7 +51,24 @@ const config: DefaultSeoProps = {
   },
 }
 
-const SEO: React.FC<Props> = ({ image, author, post, content, currentUrl, alternateMarkdownHref, ...props }) => {
+const SEO: React.FC<Props> = ({
+  image,
+  author,
+  post,
+  content,
+  currentUrl,
+  alternateMarkdownHref,
+  preview = false,
+  ...props
+}) => {
+  if (preview)
+    return (
+      <Head>
+        <title>Draft preview · Railway Blog</title>
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="referrer" content="no-referrer" />
+      </Head>
+    )
   const description = props.description || config.description
   const fullUrl = currentUrl || url
 

--- a/hooks/useFathom.ts
+++ b/hooks/useFathom.ts
@@ -1,19 +1,25 @@
 import * as Fathom from "fathom-client"
 import { useRouter } from "next/router"
 import { useEffect } from "react"
+import { hasPreviewURL, isContentPreview } from "@lib/preview-tracking"
 
 const useFathom = (trackingCode: string, siteUrl: string) => {
   const router = useRouter()
 
   useEffect(() => {
-    // Initialize Fathom when the app loads
-    Fathom.load(trackingCode, {
-      includedDomains: [siteUrl],
-    })
-
-    const onRouteChangeComplete = () => {
-      Fathom.trackPageview()
+    let loaded = false
+    const onRouteChangeComplete = (destination?: string) => {
+      if (hasPreviewURL(destination) || isContentPreview()) return
+      if (!loaded) {
+        Fathom.load(trackingCode, { includedDomains: [siteUrl], auto: false })
+        loaded = true
+      }
+      Fathom.trackPageview({
+        url: window.location.href,
+        referrer: hasPreviewURL(document.referrer) ? "" : document.referrer,
+      })
     }
+    onRouteChangeComplete()
     // Record a pageview when route changes
     router.events.on("routeChangeComplete", onRouteChangeComplete)
 
@@ -21,7 +27,7 @@ const useFathom = (trackingCode: string, siteUrl: string) => {
     return () => {
       router.events.off("routeChangeComplete", onRouteChangeComplete)
     }
-  }, [])
+  }, [router.events, trackingCode, siteUrl])
 }
 
 export default useFathom

--- a/hooks/usePostHog.ts
+++ b/hooks/usePostHog.ts
@@ -1,6 +1,12 @@
 import { useEffect, useRef } from "react"
 import Router from "next/router"
 import type { PostHog } from "posthog-js"
+import {
+  filterPreviewEvent,
+  hasPreviewURL,
+  isContentPreview,
+  setPreviewTransition,
+} from "@lib/preview-tracking"
 
 const POSTHOG_SESSION_ID_KEY = "railway_posthog_session_id"
 const POSTHOG_DOMAIN = process.env.NEXT_PUBLIC_POSTHOG_PUBLIC_DOMAIN ?? ""
@@ -10,64 +16,91 @@ const usePostHog = () => {
   const posthogRef = useRef<PostHog | null>(null)
 
   useEffect(() => {
-    // if (process.env.NODE_ENV === "development") return
-    if (typeof window === "undefined") return
-
     let cancelled = false
-    let handleRouteChange: (() => void) | null = null
+    let recordingSettings: Pick<
+      PostHog["config"],
+      "disable_session_recording" | "autocapture" | "enable_heatmaps"
+    > | null = null
+    const syncRecording = () => {
+      const ph = posthogRef.current
+      if (!ph) return
+      if (isContentPreview()) {
+        if (recordingSettings) return
+        recordingSettings = {
+          disable_session_recording: ph.config.disable_session_recording,
+          autocapture: ph.config.autocapture,
+          enable_heatmaps: ph.config.enable_heatmaps,
+        }
+        ph.set_config({
+          disable_session_recording: true,
+          autocapture: false,
+          enable_heatmaps: false,
+        })
+      } else if (recordingSettings) {
+        ph.set_config(recordingSettings)
+        recordingSettings = null
+      }
+    }
 
-    const load = () => import("posthog-js").then(({ default: posthog }) => {
-      if (cancelled) return
-      posthogRef.current = posthog
-
-      const isInitialized =
-        typeof (posthog as any).persistence?.get_sessionid === "function" ||
-        typeof (posthog as any)._send_request === "function"
-
-      if (!isInitialized) {
-        posthog.init(POSTHOG_KEY, {
+    const trackPublicPage = async () => {
+      if (cancelled || isContentPreview()) return
+      const { default: ph } = await import("posthog-js")
+      if (cancelled || isContentPreview()) return
+      if (!posthogRef.current) {
+        posthogRef.current = ph
+        ph.init(POSTHOG_KEY, {
           api_host: POSTHOG_DOMAIN,
           advanced_disable_decide: true,
-          loaded: (ph) => {
-            const sessionId = ph.get_session_id()
+          capture_pageview: false,
+          capture_pageleave: false,
+          before_send: filterPreviewEvent,
+          loaded: (instance) => {
+            syncRecording()
+            if (isContentPreview()) return
+            const sessionId = instance.get_session_id()
             if (sessionId) {
               localStorage.setItem(POSTHOG_SESSION_ID_KEY, sessionId)
-              ph.register({ sessionId })
+              instance.register({ sessionId })
             }
           },
         })
-      } else {
-        const sessionId =
-          localStorage.getItem(POSTHOG_SESSION_ID_KEY) ||
-          posthog.get_session_id()
-        if (sessionId) {
-          localStorage.setItem(POSTHOG_SESSION_ID_KEY, sessionId)
-          posthog.register({ sessionId })
-        }
       }
-
-      handleRouteChange = () => posthog.capture("$pageview")
-      Router.events.on("routeChangeComplete", handleRouteChange)
-    })
-
-    if (typeof requestIdleCallback === "function") {
-      requestIdleCallback(load)
-    } else {
-      setTimeout(load, 0)
+      syncRecording()
+      ph.capture("$pageview")
     }
-
+    const start = (destination: string) => {
+      setPreviewTransition(hasPreviewURL(destination))
+      syncRecording()
+    }
+    const complete = () => {
+      setPreviewTransition(false)
+      syncRecording()
+      void trackPublicPage()
+    }
+    const failed = () => {
+      setPreviewTransition(false)
+      syncRecording()
+    }
+    Router.events.on("routeChangeStart", start)
+    Router.events.on("routeChangeComplete", complete)
+    Router.events.on("routeChangeError", failed)
+    void trackPublicPage()
     return () => {
       cancelled = true
-      if (handleRouteChange) {
-        Router.events.off("routeChangeComplete", handleRouteChange)
-      }
+      setPreviewTransition(false)
+      Router.events.off("routeChangeStart", start)
+      Router.events.off("routeChangeComplete", complete)
+      Router.events.off("routeChangeError", failed)
     }
   }, [])
 
   return {
-    identify: (id: string, traits?: Record<string, any>) =>
-      posthogRef.current?.identify(id, traits),
-    reset: () => posthogRef.current?.reset(),
+    identify: (id: string, traits?: Record<string, unknown>) => {
+      if (!isContentPreview()) posthogRef.current?.identify(id, traits)
+    },
+    reset: () => {
+      if (!isContentPreview()) posthogRef.current?.reset()
+    },
   }
 }
 

--- a/layouts/PostPage.tsx
+++ b/layouts/PostPage.tsx
@@ -18,9 +18,16 @@ import { cn, formatPostDate, getReadingTime } from "../utils"
 export interface Props {
   post: BlogPost
   relatedPosts: BlogPost[]
+  preview?: boolean
 }
 
-export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
+export const PostPage: React.FC<Props> = ({
+  post,
+  relatedPosts,
+  preview = false,
+}) => {
+  const hasPublishedDate =
+    Boolean(post.publishedAt) && Number.isFinite(Date.parse(post.publishedAt))
   const formattedDate = useMemo(
     () => formatPostDate(post.publishedAt),
     [post.publishedAt]
@@ -47,6 +54,7 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
   return (
     <Page
       seo={{
+        preview,
         title: post.seoTitle ?? buildSeoTitle(post.title),
         description:
           post.seoDescription ?? buildMetaDescription(post.description),
@@ -58,6 +66,14 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
         alternateMarkdownHref: `/p/${post.slug}.md`,
       }}
     >
+      {preview && (
+        <div
+          role="status"
+          className="fixed bottom-4 left-4 right-4 sm:right-auto z-50 rounded-lg border border-gray-200 bg-background px-4 py-3 text-sm shadow-lg"
+        >
+          Draft preview · Latest saved content
+        </div>
+      )}
       <div className="mt-10 mb-5 px-5 md:px-8 mx-auto">
         <article
           className={cn(
@@ -90,10 +106,12 @@ export const PostPage: React.FC<Props> = ({ post, relatedPosts }) => {
                   </div>
                   <span>{authorName}</span>
                 </div>
-                <Divider />
+                {hasPublishedDate && <Divider />}
               </>
             )}
-            <time dateTime={post.publishedAt}>{formattedDate}</time>
+            {hasPublishedDate && (
+              <time dateTime={post.publishedAt}>{formattedDate}</time>
+            )}
           </div>
 
           <header className="mt-5 mb-16 max-w-[704px] mx-auto">

--- a/lib/cms/index.ts
+++ b/lib/cms/index.ts
@@ -337,15 +337,16 @@ export const mapCMSCategory = (
   }
 }
 
-export const mapCMSPost = (post: PayloadPost): BlogPost | null => {
+const mapPost = (post: PayloadPost, preview: boolean): BlogPost | null => {
   if (
     !post ||
-    (post._status != null && post._status !== "published") ||
+    (!preview && post._status != null && post._status !== "published") ||
     post.archivedAt != null ||
-    typeof post.title !== "string" ||
     typeof post.slug !== "string" ||
-    typeof post.description !== "string" ||
-    typeof post.publishedAt !== "string"
+    (!preview &&
+      (typeof post.title !== "string" ||
+        typeof post.description !== "string" ||
+        typeof post.publishedAt !== "string"))
   ) {
     return null
   }
@@ -358,21 +359,26 @@ export const mapCMSPost = (post: PayloadPost): BlogPost | null => {
     authors,
     category: mapCMSCategory(post.category),
     content: typeof post.content === "string" ? post.content : null,
-    createdAt: post.createdAt ?? post.publishedAt,
-    description: post.description,
+    createdAt: post.createdAt ?? post.publishedAt ?? "",
+    description: post.description ?? "",
     externalAuthor: Boolean(post.externalAuthor),
     featured: Boolean(post.featured),
     featuredImage: mapCMSMedia(post.featuredImage),
     id: String(post.id),
-    publishedAt: post.publishedAt,
+    publishedAt: post.publishedAt ?? "",
     seoDescription: nonEmptyString(post.seoDescription),
     seoTitle: nonEmptyString(post.seoTitle),
     slug: post.slug,
     socialImage: mapCMSMedia(post.socialImage),
-    title: post.title,
-    updatedAt: post.updatedAt ?? post.publishedAt,
+    title: preview ? post.title || "Untitled post" : post.title,
+    updatedAt: post.updatedAt ?? post.publishedAt ?? "",
   }
 }
+
+export const mapCMSPost = (post: PayloadPost) => mapPost(post, false)
+
+// Only use with the projection returned by the authorized content-preview endpoint.
+export const mapCMSPreviewPost = (post: PayloadPost) => mapPost(post, true)
 
 export const getBlogLink = (slug: string) => `/p/${slug}`
 

--- a/lib/cms/preview.server.ts
+++ b/lib/cms/preview.server.ts
@@ -1,0 +1,41 @@
+import { mapCMSPreviewPost } from "@lib/cms"
+import { postPreviewPath, previewToken } from "./preview"
+
+/** The CMS checks the signature and persisted grant on every read. */
+export async function getPreviewPost(slug: unknown, token: unknown) {
+  const path = postPreviewPath(slug)
+  const validatedToken = previewToken(token)
+  if (!path || !validatedToken) return null
+
+  const url = new URL(
+    "/api/content-preview",
+    process.env.CMS_API_URL || "https://cms.railway.com"
+  )
+  url.searchParams.set("collection", "posts")
+  url.searchParams.set("path", path)
+  url.searchParams.set("token", validatedToken)
+
+  // This document-scoped token is the credential; never attach the service key.
+  const response = await fetch(url, {
+    cache: "no-store",
+    redirect: "error",
+    signal: AbortSignal.timeout(8000),
+  })
+  if ([400, 401, 403, 404, 410].includes(response.status)) return null
+  if (!response.ok) throw new Error("CMS preview temporarily unavailable")
+
+  const result = await response.json()
+  if (
+    !result ||
+    result.collection !== "posts" ||
+    result.path !== path ||
+    result.preview !== true ||
+    !result.document ||
+    typeof result.document !== "object" ||
+    Array.isArray(result.document) ||
+    result.document.slug !== slug
+  )
+    throw new Error("Invalid CMS preview response")
+
+  return mapCMSPreviewPost(result.document)
+}

--- a/lib/cms/preview.ts
+++ b/lib/cms/preview.ts
@@ -1,0 +1,24 @@
+export const previewHeaders = {
+  "Cache-Control": "private, no-store",
+  "X-Robots-Tag": "noindex, nofollow",
+  "Referrer-Policy": "no-referrer",
+}
+
+export const previewToken = (value: unknown): string | null =>
+  typeof value === "string" && value.length > 0 && value.length <= 1024
+    ? value
+    : null
+
+export const postPreviewPath = (slug: unknown): string | null => {
+  if (
+    typeof slug !== "string" ||
+    !slug.trim() ||
+    slug !== slug.trim() ||
+    slug.length > 240 ||
+    /[/?#\\]/.test(slug) ||
+    [".", ".."].includes(slug)
+  )
+    return null
+  const path = `/p/${encodeURIComponent(slug)}`
+  return path.length <= 512 ? path : null
+}

--- a/lib/preview-tracking.ts
+++ b/lib/preview-tracking.ts
@@ -1,0 +1,62 @@
+import type { BeforeSendFn } from "posthog-js"
+
+export const hasPreviewURL = (value: unknown): boolean => {
+  if (typeof value !== "string") return false
+  try {
+    const url = new URL(value, "https://blog.railway.com")
+    return (
+      url.searchParams.has("cmsPreview") || url.pathname.startsWith("/preview/")
+    )
+  } catch {
+    return false
+  }
+}
+
+// Block capture before a client transition can render draft DOM.
+let enteringPreview = false
+export const setPreviewTransition = (value: boolean) => {
+  enteringPreview = value
+}
+export const isContentPreview = () =>
+  enteringPreview ||
+  (typeof window !== "undefined" && hasPreviewURL(window.location.href))
+
+const redactPreviewURLs = (value: unknown): unknown => {
+  if (typeof value === "string") return hasPreviewURL(value) ? undefined : value
+  if (Array.isArray(value))
+    return value.map((item) => redactPreviewURLs(item) ?? null)
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .map(([key, item]) => [key, redactPreviewURLs(item)])
+        .filter(([, item]) => item !== undefined)
+    )
+  }
+  return value
+}
+
+export const filterPreviewEvent: BeforeSendFn = (event) => {
+  if (
+    !event ||
+    isContentPreview() ||
+    hasPreviewURL(event.properties.$current_url)
+  )
+    return null
+  // These SDK buffers are opaque; never recursively copy recording/heatmap payloads.
+  const payloadKey =
+    event.event === "$snapshot"
+      ? "$snapshot_data"
+      : event.event === "$$heatmap"
+      ? "$heatmap_data"
+      : undefined
+  if (payloadKey && payloadKey in event.properties) {
+    const { [payloadKey]: payload, ...metadata } = event.properties
+    const filtered = redactPreviewURLs({
+      ...event,
+      properties: metadata,
+    }) as typeof event
+    filtered.properties[payloadKey] = payload
+    return filtered
+  }
+  return redactPreviewURLs(event) as typeof event
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server"
+import { previewHeaders } from "./lib/cms/preview"
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl
+  if (!url.searchParams.has("cmsPreview")) return NextResponse.next()
+
+  // Presence, including empty/duplicate tokens, must bypass the published cache.
+  // Markdown exports remain published-only; a preview token is never an export credential.
+  if (!/^\/p\/[^/]+$/.test(url.pathname) || url.pathname.endsWith(".md")) {
+    return new NextResponse(
+      "Preview unavailable. Open the original preview link.",
+      {
+        status: 404,
+        headers: previewHeaders,
+      }
+    )
+  }
+
+  const destination = url.clone()
+  destination.pathname = `/preview${url.pathname}`
+  return NextResponse.rewrite(destination, { headers: previewHeaders })
+}
+
+export const config = { matcher: ["/p/:path*"] }

--- a/pages/preview/p/[slug].tsx
+++ b/pages/preview/p/[slug].tsx
@@ -1,0 +1,45 @@
+import { PostPage } from "@layouts/PostPage"
+import Page from "@layouts/Page"
+import { previewHeaders } from "@lib/cms/preview"
+import { getPreviewPost } from "@lib/cms/preview.server"
+import { BlogPost } from "@lib/types"
+import { GetServerSideProps } from "next"
+
+interface Props {
+  post: BlogPost | null
+  unavailable?: boolean
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  params,
+  query,
+  res,
+}) => {
+  for (const [name, value] of Object.entries(previewHeaders))
+    res.setHeader(name, value)
+  try {
+    const post = await getPreviewPost(params?.slug, query.cmsPreview)
+    if (!post) res.statusCode = 404
+    return { props: { post } }
+  } catch {
+    // Do not log fetch errors: they can contain the credential-bearing URL.
+    res.statusCode = 503
+    return { props: { post: null, unavailable: true } }
+  }
+}
+
+export default function PreviewPost({ post, unavailable }: Props) {
+  if (post) return <PostPage post={post} relatedPosts={[]} preview />
+  return (
+    <Page seo={{ preview: true }}>
+      <main className="mx-auto max-w-[704px] px-5 pt-32 pb-24">
+        <h1 className="text-3xl font-serif">Preview unavailable</h1>
+        <p className="mt-4 text-gray-600">
+          {unavailable
+            ? "We couldn't load this preview. Please try again shortly."
+            : "This link is invalid or no longer active. Ask the author for a new preview link."}
+        </p>
+      </main>
+    </Page>
+  )
+}

--- a/test/cms/preview.test.ts
+++ b/test/cms/preview.test.ts
@@ -1,0 +1,119 @@
+/** @jest-environment node */
+import { getPreviewPost } from "@lib/cms/preview.server"
+import { mapCMSPost, mapCMSPreviewPost, getPosts } from "@lib/cms"
+
+const draft = {
+  id: 9,
+  slug: "new-post",
+  title: "Draft title",
+  _status: "draft" as const,
+}
+const mockFetch = jest.fn()
+beforeEach(() => {
+  mockFetch.mockReset()
+  global.fetch = mockFetch
+  process.env.CMS_API_URL = "https://cms.example"
+})
+const response = (
+  status: number,
+  document: unknown = draft,
+  envelope = {}
+) => ({
+  ok: status === 200,
+  status,
+  json: async () => ({
+    collection: "posts",
+    path: "/p/new-post",
+    preview: true,
+    document,
+    ...envelope,
+  }),
+})
+
+it.each([undefined, "", ["token", "other"], "x".repeat(1025)])(
+  "rejects invalid token %j without reading CMS",
+  async (token) => {
+    expect(await getPreviewPost("new-post", token)).toBeNull()
+    expect(mockFetch).not.toHaveBeenCalled()
+  }
+)
+it.each(["../private", "a/b", "a?b", "", undefined])(
+  "rejects invalid slug %j",
+  async (slug) => {
+    expect(await getPreviewPost(slug, "token")).toBeNull()
+    expect(mockFetch).not.toHaveBeenCalled()
+  }
+)
+it("reads only the authorized projection without a service key and without caching", async () => {
+  mockFetch.mockResolvedValue(response(200))
+  expect(await getPreviewPost("new-post", "token")).toMatchObject({
+    title: "Draft title",
+    description: "",
+    publishedAt: "",
+    authors: [],
+  })
+  const [url, options] = mockFetch.mock.calls[0]
+  expect(url.origin).toBe("https://cms.example")
+  expect(url.pathname).toBe("/api/content-preview")
+  expect(Object.fromEntries(url.searchParams)).toEqual({
+    collection: "posts",
+    path: "/p/new-post",
+    token: "token",
+  })
+  expect(options).toMatchObject({ cache: "no-store", redirect: "error" })
+  expect(options.headers).toBeUndefined()
+})
+it.each([400, 401, 403, 404, 410])(
+  "does not fall back to published content on CMS %s",
+  async (status) => {
+    mockFetch.mockResolvedValue(response(status))
+    expect(await getPreviewPost("new-post", "token")).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  }
+)
+it("keeps temporary failures distinct from unavailable links", async () => {
+  mockFetch.mockResolvedValue(response(503))
+  await expect(getPreviewPost("new-post", "token")).rejects.toThrow(
+    "temporarily unavailable"
+  )
+})
+it.each([
+  { collection: "job-postings" },
+  { path: "/p/other" },
+  { preview: false },
+  { document: [] },
+  { document: { ...draft, slug: "other" } },
+])("rejects a mismatched CMS response %j", async (envelope) => {
+  mockFetch.mockResolvedValue(response(200, draft, envelope))
+  await expect(getPreviewPost("new-post", "token")).rejects.toThrow(
+    "Invalid CMS preview response"
+  )
+})
+it("keeps normal post mapping published-only and allows incomplete previews", () => {
+  const complete = {
+    ...draft,
+    description: "Description",
+    publishedAt: "2026-09-11",
+  }
+  expect(mapCMSPost(complete)).toBeNull()
+  expect(mapCMSPreviewPost(draft)).toMatchObject({
+    title: "Draft title",
+    publishedAt: "",
+  })
+  expect(mapCMSPreviewPost({ ...draft, title: null })).toMatchObject({
+    title: "Untitled post",
+  })
+  expect(mapCMSPreviewPost({ ...draft, archivedAt: "2026-09-11" })).toBeNull()
+})
+it("all public post consumers still filter drafts and archives", async () => {
+  process.env.CMS_API_KEY = "test-published-key"
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ docs: [], hasNextPage: false }),
+  })
+  await getPosts()
+  const url = new URL(mockFetch.mock.calls[0][0])
+  expect(url.searchParams.get("where[_status][equals]")).toBe("published")
+  expect(url.searchParams.get("where[archivedAt][exists]")).toBe("false")
+  expect(url.searchParams.has("draft")).toBe(false)
+})

--- a/test/components/Seo.test.tsx
+++ b/test/components/Seo.test.tsx
@@ -223,3 +223,25 @@ describe("serializeSchema", () => {
     expect(serializeSchema(schema)).toBe(JSON.stringify(schema))
   })
 })
+
+it("omits public metadata and draft details from preview heads", () => {
+  const { container } = render(
+    <SEO
+      preview
+      post={post}
+      title="Secret draft"
+      content="Secret content"
+      image="https://og.railway.com/secret"
+      alternateMarkdownHref="/p/secret.md"
+    />
+  )
+  expect(mockNextSeoCalls).toHaveLength(0)
+  expect(
+    document.querySelector('meta[name="robots"]')?.getAttribute("content")
+  ).toBe("noindex, nofollow")
+  expect(
+    document.querySelector('meta[name="referrer"]')?.getAttribute("content")
+  ).toBe("no-referrer")
+  expect(container.querySelector("script, link, meta[property] ")).toBeNull()
+  expect(container.innerHTML).not.toContain("Secret")
+})

--- a/test/hooks/preview-analytics.test.tsx
+++ b/test/hooks/preview-analytics.test.tsx
@@ -1,0 +1,103 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import usePostHog from "@hooks/usePostHog"
+import useFathom from "@hooks/useFathom"
+import { setPreviewTransition } from "@lib/preview-tracking"
+import * as Fathom from "fathom-client"
+import posthog from "posthog-js"
+
+const mockHandlers = new Map<string, Set<(...args: any[]) => void>>()
+const mockEvents = {
+  on: (name: string, fn: (...args: any[]) => void) => {
+    if (!mockHandlers.has(name)) mockHandlers.set(name, new Set())
+    mockHandlers.get(name)?.add(fn)
+  },
+  off: (name: string, fn: (...args: any[]) => void) =>
+    mockHandlers.get(name)?.delete(fn),
+}
+jest.mock("next/router", () => ({
+  __esModule: true,
+  default: {
+    get events() {
+      return mockEvents
+    },
+  },
+  useRouter: () => ({ events: mockEvents }),
+}))
+jest.mock("fathom-client", () => ({
+  load: jest.fn(),
+  trackPageview: jest.fn(),
+}))
+jest.mock("posthog-js", () => {
+  const ph = {
+    config: {
+      disable_session_recording: false,
+      autocapture: true,
+      enable_heatmaps: true,
+    },
+    init: jest.fn((_key, config) => {
+      Object.assign(ph.config, config)
+      config.loaded(ph)
+    }),
+    set_config: jest.fn((config) => Object.assign(ph.config, config)),
+    capture: jest.fn(),
+    register: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    get_session_id: () => "test-session",
+  }
+  return { __esModule: true, default: ph }
+})
+const emit = (name: string, ...args: any[]) =>
+  mockHandlers.get(name)?.forEach((fn) => fn(...args))
+const navigate = async (url: string) => {
+  await act(async () => {
+    emit("routeChangeStart", url)
+    window.history.pushState({}, "", url)
+    emit("routeChangeComplete", url)
+  })
+}
+beforeEach(() => {
+  mockHandlers.clear()
+  jest.clearAllMocks()
+  setPreviewTransition(false)
+  window.history.replaceState({}, "", "/")
+  Object.assign(posthog.config, {
+    disable_session_recording: false,
+    autocapture: true,
+    enable_heatmaps: true,
+  })
+})
+it("does not initialize analytics on previews and starts them after leaving", async () => {
+  window.history.replaceState({}, "", "/p/draft?cmsPreview=secret")
+  renderHook(() => {
+    usePostHog()
+    useFathom("test", "blog.railway.com")
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+  expect(posthog.init).not.toHaveBeenCalled()
+  expect(Fathom.load).not.toHaveBeenCalled()
+  await navigate("/p/public")
+  await waitFor(() => expect(posthog.capture).toHaveBeenCalledTimes(1))
+  expect(Fathom.trackPageview).toHaveBeenCalledTimes(1)
+})
+it("stops recording before entering a preview and resumes on a public page", async () => {
+  renderHook(() => {
+    usePostHog()
+    useFathom("test", "blog.railway.com")
+  })
+  await waitFor(() => expect(posthog.capture).toHaveBeenCalledTimes(1))
+  act(() => emit("routeChangeStart", "/p/draft?cmsPreview=secret"))
+  expect(posthog.config.disable_session_recording).toBe(true)
+  expect(posthog.config.autocapture).toBe(false)
+  expect((posthog.config.before_send as any)({ properties: {} })).toBeNull()
+  await navigate("/p/draft?cmsPreview=secret")
+  expect(posthog.capture).toHaveBeenCalledTimes(1)
+  expect(Fathom.trackPageview).toHaveBeenCalledTimes(1)
+  await navigate("/p/public")
+  expect(posthog.config.disable_session_recording).toBe(false)
+  expect(posthog.config.autocapture).toBe(true)
+  expect(posthog.capture).toHaveBeenCalledTimes(2)
+  expect(Fathom.trackPageview).toHaveBeenCalledTimes(2)
+})

--- a/test/pages/preview.test.tsx
+++ b/test/pages/preview.test.tsx
@@ -1,0 +1,30 @@
+import { getServerSideProps } from "../../pages/preview/p/[slug]"
+import { getPreviewPost } from "@lib/cms/preview.server"
+import { previewHeaders } from "@lib/cms/preview"
+jest.mock("@lib/cms/preview.server", () => ({ getPreviewPost: jest.fn() }))
+jest.mock("@layouts/PostPage", () => ({ PostPage: () => null }))
+jest.mock("@layouts/Page", () => ({ __esModule: true, default: () => null }))
+
+it.each(["ok", "missing", "failure"])(
+  "keeps preview %s responses private and correctly status-coded",
+  async (outcome) => {
+    const post = { id: "9", title: "Draft", slug: "new-post" }
+    const mock = getPreviewPost as jest.Mock
+    if (outcome === "failure")
+      mock.mockRejectedValue(new Error("upstream token must not be logged"))
+    else mock.mockResolvedValue(outcome === "ok" ? post : null)
+    const res = { setHeader: jest.fn(), statusCode: 200 }
+    const result = await getServerSideProps({
+      params: { slug: "new-post" },
+      query: { cmsPreview: "token" },
+      res,
+    } as any)
+    expect(res.statusCode).toBe(
+      outcome === "ok" ? 200 : outcome === "missing" ? 404 : 503
+    )
+    for (const [key, value] of Object.entries(previewHeaders))
+      expect(res.setHeader).toHaveBeenCalledWith(key, value)
+    expect(result).not.toHaveProperty("revalidate")
+    expect(JSON.stringify(result)).not.toContain("token")
+  }
+)

--- a/test/preview-middleware.test.ts
+++ b/test/preview-middleware.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+import { middleware } from "../middleware"
+import { previewHeaders } from "@lib/cms/preview"
+jest.mock("next/server", () => ({
+  NextResponse: Object.assign(
+    class {
+      constructor(public body: string, public init: unknown) {}
+    },
+    {
+      next: () => ({ next: true }),
+      rewrite: (url: URL, init: unknown) => ({ url, init }),
+    }
+  ),
+}))
+const request = (path: string) => {
+  const url = new URL(path, "https://blog.railway.com")
+  return { nextUrl: Object.assign(url, { clone: () => new URL(url) }) } as any
+}
+it("preserves the published route without a preview query", () => {
+  expect(middleware(request("/p/post"))).toEqual({ next: true })
+})
+it.each(["token", "", "one&cmsPreview=two"])(
+  "routes token %s away from ISR",
+  (value) => {
+    const response = middleware(request(`/p/post?cmsPreview=${value}`)) as any
+    expect(response.url.pathname).toBe("/preview/p/post")
+    expect(response.url.searchParams.has("cmsPreview")).toBe(true)
+    expect(response.init.headers).toEqual(previewHeaders)
+  }
+)
+it.each(["/p/post.md", "/p/post/markdown"])(
+  "rejects preview Markdown exports %s",
+  (path) => {
+    const response = middleware(request(`${path}?cmsPreview=token`)) as any
+    expect(response.init).toEqual({ status: 404, headers: previewHeaders })
+  }
+)

--- a/test/preview-tracking.test.ts
+++ b/test/preview-tracking.test.ts
@@ -1,0 +1,56 @@
+import {
+  filterPreviewEvent,
+  hasPreviewURL,
+  setPreviewTransition,
+} from "@lib/preview-tracking"
+const preview = "/p/post?cmsPreview=secret"
+const event = (properties = {}, name = "$pageview") =>
+  ({
+    event: name,
+    properties: {
+      $current_url: "https://blog.railway.com/p/public",
+      ...properties,
+    },
+  } as any)
+beforeEach(() => {
+  window.history.replaceState({}, "", "/")
+  setPreviewTransition(false)
+})
+it.each([preview, "/p/post?cmsPreview=", "/preview/p/post"])(
+  "recognizes preview context %s",
+  (url) => {
+    expect(hasPreviewURL(url)).toBe(true)
+    window.history.replaceState({}, "", url)
+    expect(filterPreviewEvent(event())).toBeNull()
+  }
+)
+it("blocks capture before preview DOM arrives and rejects deferred preview events", () => {
+  setPreviewTransition(true)
+  expect(filterPreviewEvent(event())).toBeNull()
+  setPreviewTransition(false)
+  expect(filterPreviewEvent(event({ $current_url: preview }))).toBeNull()
+  expect(filterPreviewEvent(event())).not.toBeNull()
+})
+it("removes preview URLs from public referrer and session properties", () => {
+  const result = filterPreviewEvent(
+    event({
+      $referrer: preview,
+      nested: { previous: preview, public: "/p/public" },
+      list: [preview, "safe"],
+    })
+  ) as any
+  expect(result.properties.$referrer).toBeUndefined()
+  expect(result.properties.nested).toEqual({ public: "/p/public" })
+  expect(result.properties.list).toEqual([null, "safe"])
+})
+it.each([
+  ["$snapshot", "$snapshot_data"],
+  ["$$heatmap", "$heatmap_data"],
+])("preserves opaque %s buffers", (name, key) => {
+  const buffer = [{ data: "sdk data" }]
+  const result = filterPreviewEvent(
+    event({ [key]: buffer, $referrer: preview }, name)
+  ) as any
+  expect(result.properties[key]).toBe(buffer)
+  expect(result.properties.$referrer).toBeUndefined()
+})


### PR DESCRIPTION
Blog authors can open a CMS-generated link to the latest saved draft, including posts that have never been published. Requests with `cmsPreview` bypass the published ISR page and use a private, uncached server-rendered reader that validates the grant with the CMS on every request.

Preview pages reuse the article layout with a draft indicator, omit public article metadata, and suppress analytics and session recording across client navigation. Feeds, Markdown exports, and ordinary post URLs remain published-only. Invalid links return 404; temporary CMS failures return 503.

Validation: production build, TypeScript, changed-file ESLint, and all 50 focused tests pass. Two real production servers passed 21 HTTP checks, and Chrome passed desktop/mobile rendering, client transitions, Back navigation, metadata cleanup, and invalid-link checks. Live save, replacement, revocation, slug-change, archive, and upstream-outage checks also pass. The full blog suite has three existing failing suites, reproduced on unchanged `origin/main`: two `react-markdown` ESM loading failures under the installed pnpm layout and one unrelated excerpt assertion.

Deploy this reader before the CMS companion, https://github.com/railwayapp/mono/pull/39011. No new blog secret is required; the existing `CMS_API_URL` points at the CMS that validates the document-scoped token.
